### PR TITLE
Open firmware.bin in a temp directory

### DIFF
--- a/src/api/src/services/Firmware/index.ts
+++ b/src/api/src/services/Firmware/index.ts
@@ -362,10 +362,27 @@ export default class FirmwareService {
 
           try {
             await fs.promises.copyFile(firmwareBinPath, newfirmwareBinPath);
-            firmwareBinPath = newfirmwareBinPath;
           } catch (err) {
             this.logger?.error(
               `error copying file from ${firmwareBinPath} to ${newfirmwareBinPath}: ${err}`
+            );
+          }
+
+          // copy actual firmware.bin into tmp system directory
+          const tmpPath = await fs.promises.mkdtemp(
+            path.join(os.tmpdir(), `${params.target}_`)
+          );
+          const tmpFirmwareBinPath = path.join(
+            tmpPath,
+            path.basename(firmwareBinPath)
+          );
+
+          try {
+            await fs.promises.copyFile(firmwareBinPath, tmpFirmwareBinPath);
+            firmwareBinPath = tmpFirmwareBinPath;
+          } catch (err) {
+            this.logger?.error(
+              `error copying file from ${firmwareBinPath} to ${tmpFirmwareBinPath}: ${err}`
             );
           }
         }


### PR DESCRIPTION
Now firmware.bin will be moved into temporary system directory after successful build and this directory will be show for the user.

Closes #40 

Already tested only on MacOS.
I have to test it on Windows and possible Debian.

![image](https://user-images.githubusercontent.com/17099950/129619467-05e2a3b0-2bdc-48c5-b5d9-76fbaf7c5c30.png)
