### PR TITLE
have OmniBox maintain the original item order if there is no search value

### DIFF
--- a/src/ui/components/Omnibox/index.tsx
+++ b/src/ui/components/Omnibox/index.tsx
@@ -46,15 +46,26 @@ const Omnibox: FunctionComponent<OmniboxProps> = ({
     values: Option[],
     { inputValue }: FilterOptionsState<Option>
   ): OptionWithMatches[] => {
-    const searchResults = new QuickScore(values, ['label']).search(inputValue);
-    return searchResults.map(
-      (result: { item: Option; matches: { label: number[][] } }) => {
-        return {
-          ...result.item,
-          matches: result.matches.label,
-        };
-      }
-    );
+    if (inputValue) {
+      const searchResults = new QuickScore(values, ['label']).search(
+        inputValue
+      );
+      return searchResults.map(
+        (result: { item: Option; matches: { label: number[][] } }) => {
+          return {
+            ...result.item,
+            matches: result.matches.label,
+          };
+        }
+      );
+    }
+    // if no inputValue, then maintain original item order
+    return values.map((item) => {
+      return {
+        ...item,
+        matches: [[0, 0]],
+      };
+    });
   };
   return (
     <Autocomplete


### PR DESCRIPTION
This PR changes the way OmniBox handles the display of items when the user has not entered a search string.  Instead of passing the items through QuickScore with no search value, which results in a change to the original ordering of items, it displays the items in the order as they were passed in.  This solves an issue with the firmware version selector where the latest release was not being displayed first.