### PR TITLE
Add Pull Request as a firmware source options

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -114,6 +114,18 @@
                 "defaultValue": "\"\"",
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "gitPullRequest",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PullRequestInput",
+                  "ofType": null
+                },
+                "defaultValue": "null",
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -200,6 +212,30 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "Release",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pullRequests",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PullRequestType",
                     "ofType": null
                   }
                 }
@@ -1220,8 +1256,99 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "GitPullRequest",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PullRequestInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "title",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "number",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "headCommitHash",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -1255,6 +1382,81 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PullRequestType",
+        "description": null,
+        "fields": [
+          {
+            "name": "title",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "number",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "headCommitHash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -1795,6 +1997,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "gitPullRequest",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PullRequestInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -2051,16 +2265,6 @@
             "deprecationReason": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Float",
-        "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
-        "fields": null,
-        "inputFields": null,
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": null

--- a/src/api/src/graphql/args/FirmwareVersionDataInput.ts
+++ b/src/api/src/graphql/args/FirmwareVersionDataInput.ts
@@ -1,6 +1,7 @@
 import { ArgsType, Field } from 'type-graphql';
 import FirmwareSource from '../../models/enum/FirmwareSource';
 import DeviceTarget from '../../library/FirmwareBuilder/Enum/DeviceTarget';
+import PullRequest from '../../models/PullRequest';
 
 @ArgsType()
 export default class TargetDeviceOptionsArgs {
@@ -22,6 +23,9 @@ export default class TargetDeviceOptionsArgs {
   @Field()
   localPath: string;
 
+  @Field(() => PullRequest)
+  gitPullRequest: PullRequest | null;
+
   constructor() {
     this.source = FirmwareSource.GitBranch;
     this.target = DeviceTarget.DIY_2400_TX_ESP32_SX1280_E28_via_UART;
@@ -29,5 +33,6 @@ export default class TargetDeviceOptionsArgs {
     this.gitBranch = '';
     this.gitCommit = '';
     this.localPath = '';
+    this.gitPullRequest = null;
   }
 }

--- a/src/api/src/graphql/inputs/FirmwareVersionDataInput.ts
+++ b/src/api/src/graphql/inputs/FirmwareVersionDataInput.ts
@@ -1,5 +1,6 @@
 import { Field, InputType } from 'type-graphql';
 import FirmwareSource from '../../models/enum/FirmwareSource';
+import PullRequest from '../../models/PullRequest';
 
 @InputType('FirmwareVersionDataInput')
 export default class FirmwareVersionDataInput {
@@ -18,11 +19,15 @@ export default class FirmwareVersionDataInput {
   @Field()
   localPath: string;
 
+  @Field(() => PullRequest)
+  gitPullRequest: PullRequest | null;
+
   constructor() {
     this.source = FirmwareSource.GitBranch;
     this.gitTag = '';
     this.gitBranch = '';
     this.gitCommit = '';
     this.localPath = '';
+    this.gitPullRequest = null;
   }
 }

--- a/src/api/src/graphql/resolvers/Sources.resolver.ts
+++ b/src/api/src/graphql/resolvers/Sources.resolver.ts
@@ -3,6 +3,7 @@ import { Inject, Service } from 'typedi';
 import OctopusGitHubClient from '../../services/GitHubClient';
 import { ConfigToken, IConfig } from '../../config';
 import Release from '../../models/Release';
+import PullRequest from '../../models/PullRequest';
 
 @Service()
 @Resolver()
@@ -31,6 +32,14 @@ export default class SourcesResolver {
   @Query(() => [Release])
   async releases() {
     return this.gitClient.loadReleases(
+      this.config.git.owner,
+      this.config.git.repositoryName
+    );
+  }
+
+  @Query(() => [PullRequest])
+  async pullRequests() {
+    return this.gitClient.loadPullRequests(
       this.config.git.owner,
       this.config.git.repositoryName
     );

--- a/src/api/src/models/PullRequest.ts
+++ b/src/api/src/models/PullRequest.ts
@@ -1,0 +1,29 @@
+import { Field, InputType, ObjectType } from 'type-graphql';
+
+@InputType('PullRequestInput')
+@ObjectType('PullRequestType')
+export default class PullRequest {
+  @Field()
+  title: string;
+
+  @Field()
+  id: number;
+
+  @Field()
+  number: number;
+
+  @Field()
+  headCommitHash: string;
+
+  constructor(
+    title: string,
+    id: number,
+    number: number,
+    headCommitHash: string
+  ) {
+    this.title = title;
+    this.id = id;
+    this.number = number;
+    this.headCommitHash = headCommitHash;
+  }
+}

--- a/src/api/src/models/enum/FirmwareSource.ts
+++ b/src/api/src/models/enum/FirmwareSource.ts
@@ -5,6 +5,7 @@ enum FirmwareSource {
   GitBranch = 'GitBranch',
   GitCommit = 'GitCommit',
   Local = 'Local',
+  GitPullRequest = 'GitPullRequest',
 }
 
 registerEnumType(FirmwareSource, {

--- a/src/api/src/services/GitHubClient/index.ts
+++ b/src/api/src/services/GitHubClient/index.ts
@@ -1,5 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import { Service } from 'typedi';
+import PullRequest from '../../models/PullRequest';
 
 export interface Release {
   tagName: string;
@@ -12,6 +13,8 @@ export interface IGitHubClient {
   loadReleases(owner: string, repository: string): Promise<Release[]>;
 
   loadBranches(owner: string, repository: string): Promise<string[]>;
+
+  loadPullRequests(owner: string, repository: string): Promise<PullRequest[]>;
 }
 
 /*
@@ -63,5 +66,25 @@ export default class OctopusGitHubClient implements IGitHubClient {
       per_page: 100,
     });
     return response.data.map((item) => item.name);
+  }
+
+  async loadPullRequests(
+    owner: string,
+    repository: string
+  ): Promise<PullRequest[]> {
+    const response = await this.client.rest.pulls.list({
+      owner,
+      repo: repository,
+      per_page: 100,
+      state: 'open',
+    });
+    return response.data.map((item) => {
+      return {
+        id: item.id,
+        number: item.number,
+        title: item.title,
+        headCommitHash: item.head.sha,
+      };
+    });
   }
 }

--- a/src/api/src/services/UserDefinesBuilder/index.ts
+++ b/src/api/src/services/UserDefinesBuilder/index.ts
@@ -8,6 +8,7 @@ import FirmwareSource from '../../models/enum/FirmwareSource';
 import UserDefine from '../../models/UserDefine';
 import TargetUserDefinesFactory from '../../factories/TargetUserDefinesFactory';
 import { LoggerService } from '../../logger';
+import PullRequest from '../../models/PullRequest';
 
 interface UserDefineFilters {
   target: DeviceTarget;
@@ -16,6 +17,7 @@ interface UserDefineFilters {
   gitBranch: string;
   gitCommit: string;
   localPath: string;
+  gitPullRequest: PullRequest | null;
 }
 
 @Service()
@@ -87,6 +89,12 @@ export default class UserDefinesBuilder {
         );
         const data = await fs.promises.readFile(userDefinesPath, 'utf8');
         return this.extractCompatibleKeys(data);
+      case FirmwareSource.GitPullRequest:
+        return fetch(
+          `${this.rawRepoUrl}/${userDefineFilters.gitPullRequest?.headCommitHash}/src/user_defines.txt`
+        )
+          .then(handleResponse)
+          .then(this.extractCompatibleKeys);
       default:
         throw new Error(
           `unsupported firmware source: ${userDefineFilters.source}`

--- a/src/ui/components/FirmwareVersionForm/index.tsx
+++ b/src/ui/components/FirmwareVersionForm/index.tsx
@@ -19,6 +19,8 @@ import {
   FirmwareVersionDataInput,
   useGetBranchesLazyQuery,
   useGetReleasesLazyQuery,
+  useGetPullRequestsLazyQuery,
+  PullRequestInput,
 } from '../../gql/generated/types';
 import { ChooseFolderResponseBody, IpcRequest } from '../../../ipc';
 import ApplicationStorage from '../../storage';
@@ -103,9 +105,20 @@ const FirmwareVersionForm: FunctionComponent<FirmwareVersionCardProps> = (
     },
   ] = useGetBranchesLazyQuery();
 
-  const loading = gitTagsLoading || gitBranchesLoading;
+  const [
+    queryGitPullRequests,
+    {
+      loading: gitPullRequestsLoading,
+      data: gitpullRequestsResponse,
+      error: pullRequestsError,
+    },
+  ] = useGetPullRequestsLazyQuery();
+
+  const loading =
+    gitTagsLoading || gitBranchesLoading || gitPullRequestsLoading;
   const gitTags = gitTagsResponse?.releases ?? [];
   const gitBranches = gitBranchesResponse?.gitBranches ?? [];
+  const gitPullRequests = gitpullRequestsResponse?.pullRequests ?? [];
 
   const [currentGitTag, setCurrentGitTag] = useState<string>(
     data?.gitTag || ''
@@ -156,6 +169,35 @@ const FirmwareVersionForm: FunctionComponent<FirmwareVersionCardProps> = (
     setLocalPath(event.target.value);
   };
 
+  const [
+    currentGitPullRequest,
+    setCurrentGitPullRequest,
+  ] = useState<PullRequestInput | null>(
+    gitPullRequests.find(
+      (item) => item.number === data?.gitPullRequest?.number
+    ) || null
+  );
+
+  const onGitPullRequest = (value: string | null) => {
+    if (value === null) {
+      setCurrentGitPullRequest(null);
+      return;
+    }
+    const pullRequest =
+      gitPullRequests.find((item) => item.number === parseInt(value, 10)) ||
+      null;
+    if (pullRequest) {
+      setCurrentGitPullRequest({
+        id: pullRequest.id,
+        number: pullRequest.number,
+        title: pullRequest.title,
+        headCommitHash: pullRequest.headCommitHash,
+      });
+    } else {
+      setCurrentGitPullRequest(null);
+    }
+  };
+
   useEffect(() => {
     const storage = new ApplicationStorage();
     storage
@@ -167,6 +209,8 @@ const FirmwareVersionForm: FunctionComponent<FirmwareVersionCardProps> = (
           if (result.gitCommit) setGitCommit(result.gitCommit);
           if (result.gitBranch) setCurrentGitBranch(result.gitBranch);
           if (result.localPath) setLocalPath(result.localPath);
+          if (result.gitPullRequest)
+            setCurrentGitPullRequest(result.gitPullRequest);
         }
       })
       .catch((err) => {
@@ -202,6 +246,9 @@ const FirmwareVersionForm: FunctionComponent<FirmwareVersionCardProps> = (
         break;
       case FirmwareSource.Local:
         break;
+      case FirmwareSource.GitPullRequest:
+        queryGitPullRequests();
+        break;
       default:
         throw new Error(`unknown firmware source: ${firmwareSource}`);
     }
@@ -214,13 +261,21 @@ const FirmwareVersionForm: FunctionComponent<FirmwareVersionCardProps> = (
       gitTag: currentGitTag,
       gitCommit,
       localPath,
+      gitPullRequest: currentGitPullRequest,
     };
     onChange(updatedData);
     const storage = new ApplicationStorage();
     storage.setFirmwareSource(updatedData).catch((err) => {
       console.error('failed to set firmware source', err);
     });
-  }, [firmwareSource, currentGitBranch, currentGitTag, gitCommit, localPath]);
+  }, [
+    firmwareSource,
+    currentGitBranch,
+    currentGitTag,
+    gitCommit,
+    localPath,
+    currentGitPullRequest,
+  ]);
 
   return (
     <>
@@ -234,6 +289,7 @@ const FirmwareVersionForm: FunctionComponent<FirmwareVersionCardProps> = (
         <Tab label="Git branch" value={FirmwareSource.GitBranch} />
         <Tab label="Git commit" value={FirmwareSource.GitCommit} />
         <Tab label="Local" value={FirmwareSource.Local} />
+        <Tab label="Git Pull Request" value={FirmwareSource.GitPullRequest} />
       </Tabs>
 
       {firmwareSource === FirmwareSource.GitTag && gitTags !== undefined && (
@@ -353,9 +409,41 @@ const FirmwareVersionForm: FunctionComponent<FirmwareVersionCardProps> = (
         </>
       )}
 
+      {firmwareSource === FirmwareSource.GitPullRequest &&
+        gitPullRequests !== undefined && (
+          <>
+            <Alert severity="warning" className={styles.dangerZone}>
+              <AlertTitle>DANGER ZONE</AlertTitle>
+              Use these sources only if you know what you are doing or was
+              instructed by project developers
+            </Alert>
+            <div className={styles.tabContents}>
+              {!loading && (
+                <Omnibox
+                  title="Git pull Requests"
+                  options={gitPullRequests.map((pullRequest) => ({
+                    label: `${pullRequest.title} #${pullRequest.number}`,
+                    value: `${pullRequest.number}`,
+                  }))}
+                  currentValue={
+                    !currentGitPullRequest
+                      ? null
+                      : {
+                          label: `${currentGitPullRequest.title} #${currentGitPullRequest.number}`,
+                          value: `${currentGitPullRequest.number}`,
+                        }
+                  }
+                  onChange={onGitPullRequest}
+                />
+              )}
+            </div>
+          </>
+        )}
+
       <Loader loading={loading} />
       <ShowAlerts severity="error" messages={branchesError} />
       <ShowAlerts severity="error" messages={tagsError} />
+      <ShowAlerts severity="error" messages={pullRequestsError} />
     </>
   );
 };

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -26,6 +26,7 @@ export type Query = {
   readonly gitBranches: ReadonlyArray<Scalars['String']>;
   readonly gitTags: ReadonlyArray<Scalars['String']>;
   readonly releases: ReadonlyArray<Release>;
+  readonly pullRequests: ReadonlyArray<PullRequestType>;
   readonly checkForUpdates: UpdatesAvailability;
   readonly availableDevicesList: ReadonlyArray<SerialPortInformation>;
 };
@@ -37,6 +38,7 @@ export type QueryTargetDeviceOptionsArgs = {
   gitBranch?: Maybe<Scalars['String']>;
   gitCommit?: Maybe<Scalars['String']>;
   localPath?: Maybe<Scalars['String']>;
+  gitPullRequest?: Maybe<PullRequestInput>;
 };
 
 export type QueryCheckForUpdatesArgs = {
@@ -195,12 +197,28 @@ export enum FirmwareSource {
   GitBranch = 'GitBranch',
   GitCommit = 'GitCommit',
   Local = 'Local',
+  GitPullRequest = 'GitPullRequest',
 }
+
+export type PullRequestInput = {
+  readonly title: Scalars['String'];
+  readonly id: Scalars['Float'];
+  readonly number: Scalars['Float'];
+  readonly headCommitHash: Scalars['String'];
+};
 
 export type Release = {
   readonly __typename?: 'Release';
   readonly tagName: Scalars['String'];
   readonly preRelease: Scalars['Boolean'];
+};
+
+export type PullRequestType = {
+  readonly __typename?: 'PullRequestType';
+  readonly title: Scalars['String'];
+  readonly id: Scalars['Float'];
+  readonly number: Scalars['Float'];
+  readonly headCommitHash: Scalars['String'];
 };
 
 export type UpdatesAvailability = {
@@ -271,6 +289,7 @@ export type FirmwareVersionDataInput = {
   readonly gitBranch?: Maybe<Scalars['String']>;
   readonly gitCommit?: Maybe<Scalars['String']>;
   readonly localPath?: Maybe<Scalars['String']>;
+  readonly gitPullRequest?: Maybe<PullRequestInput>;
 };
 
 export enum UserDefinesMode {
@@ -483,6 +502,7 @@ export type TargetDeviceOptionsQueryVariables = Exact<{
   gitBranch: Scalars['String'];
   gitCommit: Scalars['String'];
   localPath: Scalars['String'];
+  gitPullRequest?: Maybe<PullRequestInput>;
 }>;
 
 export type TargetDeviceOptionsQuery = { readonly __typename?: 'Query' } & {
@@ -512,6 +532,17 @@ export type GetBranchesQuery = { readonly __typename?: 'Query' } & Pick<
   Query,
   'gitBranches'
 >;
+
+export type GetPullRequestsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GetPullRequestsQuery = { readonly __typename?: 'Query' } & {
+  readonly pullRequests: ReadonlyArray<
+    { readonly __typename?: 'PullRequestType' } & Pick<
+      PullRequestType,
+      'id' | 'number' | 'title' | 'headCommitHash'
+    >
+  >;
+};
 
 export type GetReleasesQueryVariables = Exact<{ [key: string]: never }>;
 
@@ -1016,6 +1047,7 @@ export const TargetDeviceOptionsDocument = gql`
     $gitBranch: String!
     $gitCommit: String!
     $localPath: String!
+    $gitPullRequest: PullRequestInput
   ) {
     targetDeviceOptions(
       target: $target
@@ -1024,6 +1056,7 @@ export const TargetDeviceOptionsDocument = gql`
       gitBranch: $gitBranch
       gitCommit: $gitCommit
       localPath: $localPath
+      gitPullRequest: $gitPullRequest
     ) {
       type
       key
@@ -1052,6 +1085,7 @@ export const TargetDeviceOptionsDocument = gql`
  *      gitBranch: // value for 'gitBranch'
  *      gitCommit: // value for 'gitCommit'
  *      localPath: // value for 'localPath'
+ *      gitPullRequest: // value for 'gitPullRequest'
  *   },
  * });
  */
@@ -1190,6 +1224,66 @@ export type GetBranchesLazyQueryHookResult = ReturnType<
 export type GetBranchesQueryResult = Apollo.QueryResult<
   GetBranchesQuery,
   GetBranchesQueryVariables
+>;
+export const GetPullRequestsDocument = gql`
+  query getPullRequests {
+    pullRequests {
+      id
+      number
+      title
+      headCommitHash
+    }
+  }
+`;
+
+/**
+ * __useGetPullRequestsQuery__
+ *
+ * To run a query within a React component, call `useGetPullRequestsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetPullRequestsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetPullRequestsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetPullRequestsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetPullRequestsQuery,
+    GetPullRequestsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetPullRequestsQuery, GetPullRequestsQueryVariables>(
+    GetPullRequestsDocument,
+    options
+  );
+}
+export function useGetPullRequestsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetPullRequestsQuery,
+    GetPullRequestsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetPullRequestsQuery,
+    GetPullRequestsQueryVariables
+  >(GetPullRequestsDocument, options);
+}
+export type GetPullRequestsQueryHookResult = ReturnType<
+  typeof useGetPullRequestsQuery
+>;
+export type GetPullRequestsLazyQueryHookResult = ReturnType<
+  typeof useGetPullRequestsLazyQuery
+>;
+export type GetPullRequestsQueryResult = Apollo.QueryResult<
+  GetPullRequestsQuery,
+  GetPullRequestsQueryVariables
 >;
 export const GetReleasesDocument = gql`
   query getReleases {

--- a/src/ui/gql/queries/deviceOptions.graphql
+++ b/src/ui/gql/queries/deviceOptions.graphql
@@ -4,7 +4,8 @@ query targetDeviceOptions(
   $gitTag: String!,
   $gitBranch: String!,
   $gitCommit: String!,
-  $localPath: String!
+  $localPath: String!,
+  $gitPullRequest: PullRequestInput
 ) {
   targetDeviceOptions(
     target: $target,
@@ -12,7 +13,8 @@ query targetDeviceOptions(
     gitTag: $gitTag,
     gitBranch: $gitBranch,
     gitCommit: $gitCommit,
-    localPath: $localPath
+    localPath: $localPath,
+    gitPullRequest: $gitPullRequest
   ) {
     type
     key

--- a/src/ui/gql/queries/getPullRequests.graphql
+++ b/src/ui/gql/queries/getPullRequests.graphql
@@ -1,0 +1,8 @@
+query getPullRequests {
+  pullRequests {
+    id
+    number
+    title
+    headCommitHash
+  }
+}

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -77,6 +77,13 @@ export const validateFirmwareVersionData = (
         errors.push(new Error('Firmware release is not selected'));
       }
       break;
+    case FirmwareSource.GitPullRequest:
+      if (
+        !(data.gitPullRequest && data.gitPullRequest.headCommitHash.length > 0)
+      ) {
+        errors.push(new Error('Firmware Pull Request is not selected'));
+      }
+      break;
     default:
       throw new Error(`unknown firmware data source: ${data.source}`);
   }
@@ -229,6 +236,7 @@ const ConfiguratorView: FunctionComponent = () => {
           gitTag: firmwareVersionData.gitTag!,
           gitCommit: firmwareVersionData.gitCommit!,
           localPath: firmwareVersionData.localPath!,
+          gitPullRequest: firmwareVersionData.gitPullRequest,
         },
       });
     }
@@ -367,6 +375,11 @@ const ConfiguratorView: FunctionComponent = () => {
       case FirmwareSource.GitTag:
         setLuaScriptLocation(
           `https://raw.githubusercontent.com/ExpressLRS/ExpressLRS/${firmwareVersionData.gitTag}/src/lua/ELRS.lua`
+        );
+        break;
+      case FirmwareSource.GitPullRequest:
+        setLuaScriptLocation(
+          `https://raw.githubusercontent.com/ExpressLRS/ExpressLRS/${firmwareVersionData.gitPullRequest?.headCommitHash}/src/lua/ELRS.lua`
         );
         break;
       default:


### PR DESCRIPTION
This adds pull requests as a firmware source option.  A new tab is added under Firmware Version, Git Pull Request, which when selected will show a select box that shows the currently open pull requests from which you can choose.

Closes #43

