### PR TITLE
Newer Firmware Version Alert

### DIFF
--- a/src/ui/components/FirmwareVersionForm/index.tsx
+++ b/src/ui/components/FirmwareVersionForm/index.tsx
@@ -45,6 +45,9 @@ const useStyles = makeStyles((theme) => ({
   chooseFolderButton: {
     marginTop: `${theme.spacing(1)} !important`,
   },
+  firmwareVersionAlert: {
+    marginTop: theme.spacing(2),
+  },
 }));
 
 interface FirmwareVersionCardProps {
@@ -271,6 +274,20 @@ const FirmwareVersionForm: FunctionComponent<FirmwareVersionCardProps> = (
                   }
                   onChange={onGitTag}
                 />
+                {currentGitTag &&
+                  gitTags.filter((item) => {
+                    if (!showPreReleases) {
+                      return item.preRelease === false;
+                    }
+                    return true;
+                  })[0]?.tagName !== currentGitTag && (
+                    <Alert
+                      className={styles.firmwareVersionAlert}
+                      severity="info"
+                    >
+                      There is a newer version of the firmware available
+                    </Alert>
+                  )}
               </>
             )}
           </div>


### PR DESCRIPTION
The configurator remembers the last firmware that the user selected to assist the user in flashing the same firmware version to all their ExpressLRS hardware.  The downside to this is the user may not know when a new version of the firmware is available.  This PR adds an alert to notify the user if there is a newer version of the firmware than they currently have selected.  The alert is based on the currently selected filter, if "Show pre-releases" is not selected it will only alert about non RC releases, but will include RC releases when "Show pre-releases" is checked.

![image](https://user-images.githubusercontent.com/38869875/130548278-819f498a-39dd-4791-915f-08f645f2adba.png)

