### PR TITLE
Fix issue with expresslrs-configurator.log not being selected when opening logs folder

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -390,7 +390,7 @@ ipcMain.on(IpcRequest.OpenLogsFolder, () => {
   logger.log('received a request to logs path', {
     logsLocation,
   });
-  shell.showItemInFolder(logsPath);
+  shell.showItemInFolder(logsLocation);
 });
 
 let buildInProgress = false;


### PR DESCRIPTION
expresslrs-configurator.log is now selected when opening the logs folder

Closes #47 