### PR TITLE
Copy the firmware file to the tmpPath with the original filename.

### DIFF
--- a/src/api/src/services/Firmware/index.ts
+++ b/src/api/src/services/Firmware/index.ts
@@ -371,6 +371,22 @@ export default class FirmwareService {
             path.join(os.tmpdir(), `${params.target}_`)
           );
 
+          // copy with original filename to tmpPath
+          const tmpFirmwareBinPathOriginalName = path.join(
+            tmpPath,
+            path.basename(firmwareBinPath)
+          );
+          try {
+            await fs.promises.copyFile(
+              firmwareBinPath,
+              tmpFirmwareBinPathOriginalName
+            );
+          } catch (err) {
+            this.logger?.error(
+              `error copying file from ${firmwareBinPath} to ${tmpFirmwareBinPathOriginalName}: ${err}`
+            );
+          }
+
           const tmpFirmwareBinPath = path.join(
             tmpPath,
             `${newFirmwareBaseName}${firmwareExtension}`


### PR DESCRIPTION
The ESP backpack WIFI update process requires the name of the firmware file to specifically be firmware.  This PR copies the firmware into the temp folder with the original name as well as the more meaningful name, which will allow users with those devices to perform a WIFI update without having to rename a file.

Closes #62 