### PR TITLE
Lua, Retry, and Build Error Updates 

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -561,6 +561,111 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "luaScript",
+            "description": null,
+            "args": [
+              {
+                "name": "gitRepository",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GitRepositoryInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "source",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "FirmwareSource",
+                  "ofType": null
+                },
+                "defaultValue": "GitBranch",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "gitTag",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": "\"\"",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "gitBranch",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": "\"\"",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "gitCommit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": "\"\"",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "localPath",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": "\"\"",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "gitPullRequest",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PullRequestInput",
+                  "ofType": null
+                },
+                "defaultValue": "null",
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "LuaScript",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1791,6 +1896,29 @@
                 "name": "Float",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "LuaScript",
+        "description": null,
+        "fields": [
+          {
+            "name": "fileLocation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,6 +27,8 @@ import DeviceService from './src/services/Device';
 import TargetUserDefinesFactory from './src/factories/TargetUserDefinesFactory';
 import MulticastDnsService from './src/services/MulticastDns';
 import MulticastDnsMonitorResolver from './src/graphql/resolvers/MulticastDnsMonitor.resolver';
+import LuaService from './src/services/Lua';
+import LuaResolver from './src/graphql/resolvers/Lua.resolver';
 
 export default class ApiServer {
   app: Express | undefined;
@@ -94,6 +96,8 @@ export default class ApiServer {
 
     Container.set(TargetsService, new TargetsService(logger, deviceService));
 
+    Container.set(LuaService, new LuaService(logger));
+
     const schema = await buildSchema({
       resolvers: [
         FirmwareResolver,
@@ -101,6 +105,7 @@ export default class ApiServer {
         UpdatesResolver,
         SerialMonitorResolver,
         MulticastDnsMonitorResolver,
+        LuaResolver,
       ],
       container: Container,
       pubSub,

--- a/src/api/src/graphql/args/Lua.ts
+++ b/src/api/src/graphql/args/Lua.ts
@@ -1,0 +1,33 @@
+import { ArgsType, Field } from 'type-graphql';
+import FirmwareSource from '../../models/enum/FirmwareSource';
+import PullRequest from '../../models/PullRequest';
+
+@ArgsType()
+export default class LuaArgs {
+  @Field(() => FirmwareSource)
+  source: FirmwareSource;
+
+  @Field()
+  gitTag: string;
+
+  @Field()
+  gitBranch: string;
+
+  @Field()
+  gitCommit: string;
+
+  @Field()
+  localPath: string;
+
+  @Field(() => PullRequest)
+  gitPullRequest: PullRequest | null;
+
+  constructor() {
+    this.source = FirmwareSource.GitBranch;
+    this.gitTag = '';
+    this.gitBranch = '';
+    this.gitCommit = '';
+    this.localPath = '';
+    this.gitPullRequest = null;
+  }
+}

--- a/src/api/src/graphql/resolvers/Lua.resolver.ts
+++ b/src/api/src/graphql/resolvers/Lua.resolver.ts
@@ -1,9 +1,9 @@
 import { Arg, Args, Query, Resolver } from 'type-graphql';
 import { Service } from 'typedi';
-import TargetArgs from '../args/Target';
+import LuaArgs from '../args/Lua';
 import GitRepository from '../inputs/GitRepositoryInput';
 import LuaService from '../../services/Lua';
-import LuaScript from '../../models/luaScript';
+import LuaScript from '../../models/LuaScript';
 
 @Service()
 @Resolver()
@@ -12,10 +12,13 @@ export default class LuaResolver {
 
   @Query(() => LuaScript)
   async luaScript(
-    @Args() args: TargetArgs,
+    @Args() args: LuaArgs,
     @Arg('gitRepository') gitRepository: GitRepository
   ): Promise<LuaScript> {
-    const fileLocation = this.luaService.loadLuaScript(args, gitRepository);
+    const fileLocation = await this.luaService.loadLuaScript(
+      args,
+      gitRepository
+    );
     return { fileLocation };
   }
 }

--- a/src/api/src/graphql/resolvers/Lua.resolver.ts
+++ b/src/api/src/graphql/resolvers/Lua.resolver.ts
@@ -1,0 +1,21 @@
+import { Arg, Args, Query, Resolver } from 'type-graphql';
+import { Service } from 'typedi';
+import TargetArgs from '../args/Target';
+import GitRepository from '../inputs/GitRepositoryInput';
+import LuaService from '../../services/Lua';
+import LuaScript from '../../models/luaScript';
+
+@Service()
+@Resolver()
+export default class LuaResolver {
+  constructor(private luaService: LuaService) {}
+
+  @Query(() => LuaScript)
+  async luaScript(
+    @Args() args: TargetArgs,
+    @Arg('gitRepository') gitRepository: GitRepository
+  ): Promise<LuaScript> {
+    const fileLocation = this.luaService.loadLuaScript(args, gitRepository);
+    return { fileLocation };
+  }
+}

--- a/src/api/src/models/LuaScript.ts
+++ b/src/api/src/models/LuaScript.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from 'type-graphql';
+
+@ObjectType('LuaScript')
+export default class LuaScript {
+  @Field({ nullable: true })
+  fileLocation: string | null;
+
+  constructor(fileLocation: string | null) {
+    this.fileLocation = fileLocation;
+  }
+}

--- a/src/api/src/services/Lua/index.ts
+++ b/src/api/src/services/Lua/index.ts
@@ -1,0 +1,159 @@
+import { Octokit } from '@octokit/rest';
+import { Service } from 'typedi';
+import * as path from 'path';
+import fs from 'fs';
+import FirmwareSource from '../../models/enum/FirmwareSource';
+import TargetArgs from '../../graphql/args/Target';
+import { LoggerService } from '../../logger';
+
+interface GitRepository {
+  owner: string;
+  repositoryName: string;
+  srcFolder: string;
+}
+
+export interface ILua {
+  loadLuaScript(
+    args: TargetArgs,
+    gitRepository: GitRepository
+  ): Promise<string | null>;
+}
+
+const luaRegexp = /elrs.*\.lua/gim;
+
+@Service()
+export default class LuaService implements ILua {
+  client: Octokit;
+
+  constructor(private logger: LoggerService) {
+    this.client = new Octokit();
+  }
+
+  async loadLuaFromGitHub(
+    gitRepositoryOwner: string,
+    gitRepositoryName: string,
+    gitRepositorySrcFolder: string,
+    ref: string
+  ): Promise<string | null> {
+    if (!ref || ref.length === 0) {
+      return null;
+    }
+    try {
+      const response = await this.client.repos.getContent({
+        owner: gitRepositoryOwner,
+        repo: gitRepositoryName,
+        path: `${gitRepositorySrcFolder}/lua`,
+        ref,
+      });
+
+      const { data } = response;
+
+      // ignore non-directory responses
+      if (!Array.isArray(data)) {
+        return null;
+      }
+
+      const sorted = data
+        .filter((item) => {
+          return item.name.match(luaRegexp);
+        })
+        .sort((a, b) => {
+          if (a.name.toUpperCase() > b.name.toUpperCase()) {
+            return -1;
+          }
+
+          return 1;
+        });
+
+      if (sorted.length > 0) {
+        return sorted[0].download_url;
+      }
+
+      return null;
+    } catch (err) {
+      this.logger?.log(`failed to get lua from ref: ${ref}`, { error: err });
+      throw new Error(`failed to get lua from ref: ${ref}.  Error: ${err}`);
+    }
+  }
+
+  async loadLuaFromLocal(localPath: string): Promise<string | null> {
+    const luaDirectory = path.join(localPath, 'lua');
+
+    if (!fs.existsSync(luaDirectory)) {
+      return null;
+    }
+
+    const contents = await fs.promises.readdir(luaDirectory);
+
+    const sorted = contents
+      .filter((item) => {
+        return path.basename(item).match(luaRegexp);
+      })
+      .sort((a, b) => {
+        if (a.toUpperCase() > b.toUpperCase()) {
+          return -1;
+        }
+
+        return 1;
+      });
+
+    if (sorted.length > 0) {
+      return sorted[0];
+    }
+
+    return null;
+  }
+
+  async loadLuaScript(
+    args: TargetArgs,
+    gitRepository: GitRepository
+  ): Promise<string | null> {
+    let luaScript: string | null = null;
+
+    switch (args.source) {
+      case FirmwareSource.GitBranch:
+        luaScript = await this.loadLuaFromGitHub(
+          gitRepository.owner,
+          gitRepository.repositoryName,
+          gitRepository.srcFolder,
+          args.gitBranch
+        );
+        break;
+      case FirmwareSource.GitCommit:
+        luaScript = await this.loadLuaFromGitHub(
+          gitRepository.owner,
+          gitRepository.repositoryName,
+          gitRepository.srcFolder,
+          args.gitCommit
+        );
+        break;
+      case FirmwareSource.GitTag:
+        luaScript = await this.loadLuaFromGitHub(
+          gitRepository.owner,
+          gitRepository.repositoryName,
+          gitRepository.srcFolder,
+          args.gitTag
+        );
+        break;
+      case FirmwareSource.Local:
+        luaScript = await this.loadLuaFromLocal(args.localPath);
+        break;
+      case FirmwareSource.GitPullRequest:
+        if (args.gitPullRequest) {
+          luaScript = await this.loadLuaFromGitHub(
+            gitRepository.owner,
+            gitRepository.repositoryName,
+            gitRepository.srcFolder,
+            args.gitPullRequest.headCommitHash
+          );
+        }
+        break;
+      default:
+        throw new Error(
+          `unsupported firmware source for the lua service: ${args.source}`
+        );
+    }
+
+    return luaScript;
+  }
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -12,7 +12,7 @@ import LogsView from './views/LogsView';
 import SerialMonitorView from './views/SerialMonitorView';
 import SupportView from './views/SupportView';
 import { Config } from './config';
-import { MulticastDnsInformation } from './gql/generated/types';
+import { DeviceType, MulticastDnsInformation } from './gql/generated/types';
 import useNetworkDevices from './hooks/useNetworkDevices';
 import WifiDeviceNotification from './components/WifiDeviceNotification';
 
@@ -58,6 +58,7 @@ export default function App() {
                   selectedDevice={device}
                   networkDevices={networkDevices}
                   onDeviceChange={onDeviceChange}
+                  deviceType={DeviceType.ExpressLRS}
                 />
               </Route>
               <Route path="/backpack">
@@ -67,6 +68,7 @@ export default function App() {
                   selectedDevice={device}
                   networkDevices={networkDevices}
                   onDeviceChange={onDeviceChange}
+                  deviceType={DeviceType.Backpack}
                 />
               </Route>
               <Route path="/settings" component={SettingsView} />

--- a/src/ui/components/BuildResponse/index.tsx
+++ b/src/ui/components/BuildResponse/index.tsx
@@ -1,9 +1,17 @@
 import React, { FunctionComponent, memo } from 'react';
 import { Alert, AlertTitle } from '@mui/material';
+import { SxProps, Theme } from '@mui/system';
 import {
   BuildFirmwareErrorType,
   BuildFlashFirmwareResult,
 } from '../../gql/generated/types';
+
+const styles: SxProps<Theme> = {
+  errorMessage: {
+    whiteSpace: 'pre-wrap',
+    fontFamily: 'monospace',
+  },
+};
 
 interface BuildResponseProps {
   response: BuildFlashFirmwareResult | undefined;
@@ -39,7 +47,7 @@ const BuildResponse: FunctionComponent<BuildResponseProps> = memo(
           <Alert severity="success">Success!</Alert>
         )}
         {response !== undefined && !response.success && (
-          <Alert severity="error">
+          <Alert sx={styles.errorMessage} severity="error">
             <AlertTitle>
               {toTitle(
                 response?.errorType ?? BuildFirmwareErrorType.GenericError

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -30,6 +30,7 @@ export type Query = {
   readonly checkForUpdates: UpdatesAvailability;
   readonly availableDevicesList: ReadonlyArray<SerialPortInformation>;
   readonly availableMulticastDnsDevicesList: ReadonlyArray<MulticastDnsInformation>;
+  readonly luaScript: LuaScript;
 };
 
 export type QueryAvailableFirmwareTargetsArgs = {
@@ -75,6 +76,16 @@ export type QueryPullRequestsArgs = {
 
 export type QueryCheckForUpdatesArgs = {
   currentVersion: Scalars['String'];
+};
+
+export type QueryLuaScriptArgs = {
+  gitRepository: GitRepositoryInput;
+  source?: Maybe<FirmwareSource>;
+  gitTag?: Maybe<Scalars['String']>;
+  gitBranch?: Maybe<Scalars['String']>;
+  gitCommit?: Maybe<Scalars['String']>;
+  localPath?: Maybe<Scalars['String']>;
+  gitPullRequest?: Maybe<PullRequestInput>;
 };
 
 export type Device = {
@@ -226,6 +237,11 @@ export type MulticastDnsInformation = {
   readonly ip: Scalars['String'];
   readonly dns: Scalars['String'];
   readonly port: Scalars['Float'];
+};
+
+export type LuaScript = {
+  readonly __typename?: 'LuaScript';
+  readonly fileLocation?: Maybe<Scalars['String']>;
 };
 
 export type Mutation = {
@@ -613,6 +629,23 @@ export type GetReleasesQuery = { readonly __typename?: 'Query' } & {
       Release,
       'tagName' | 'preRelease'
     >
+  >;
+};
+
+export type LuaScriptQueryVariables = Exact<{
+  source: FirmwareSource;
+  gitTag: Scalars['String'];
+  gitBranch: Scalars['String'];
+  gitCommit: Scalars['String'];
+  localPath: Scalars['String'];
+  gitPullRequest?: Maybe<PullRequestInput>;
+  gitRepository: GitRepositoryInput;
+}>;
+
+export type LuaScriptQuery = { readonly __typename?: 'Query' } & {
+  readonly luaScript: { readonly __typename?: 'LuaScript' } & Pick<
+    LuaScript,
+    'fileLocation'
   >;
 };
 
@@ -1553,6 +1586,81 @@ export type GetReleasesLazyQueryHookResult = ReturnType<
 export type GetReleasesQueryResult = Apollo.QueryResult<
   GetReleasesQuery,
   GetReleasesQueryVariables
+>;
+export const LuaScriptDocument = gql`
+  query luaScript(
+    $source: FirmwareSource!
+    $gitTag: String!
+    $gitBranch: String!
+    $gitCommit: String!
+    $localPath: String!
+    $gitPullRequest: PullRequestInput
+    $gitRepository: GitRepositoryInput!
+  ) {
+    luaScript(
+      source: $source
+      gitTag: $gitTag
+      gitBranch: $gitBranch
+      gitCommit: $gitCommit
+      localPath: $localPath
+      gitPullRequest: $gitPullRequest
+      gitRepository: $gitRepository
+    ) {
+      fileLocation
+    }
+  }
+`;
+
+/**
+ * __useLuaScriptQuery__
+ *
+ * To run a query within a React component, call `useLuaScriptQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLuaScriptQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useLuaScriptQuery({
+ *   variables: {
+ *      source: // value for 'source'
+ *      gitTag: // value for 'gitTag'
+ *      gitBranch: // value for 'gitBranch'
+ *      gitCommit: // value for 'gitCommit'
+ *      localPath: // value for 'localPath'
+ *      gitPullRequest: // value for 'gitPullRequest'
+ *      gitRepository: // value for 'gitRepository'
+ *   },
+ * });
+ */
+export function useLuaScriptQuery(
+  baseOptions: Apollo.QueryHookOptions<LuaScriptQuery, LuaScriptQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<LuaScriptQuery, LuaScriptQueryVariables>(
+    LuaScriptDocument,
+    options
+  );
+}
+export function useLuaScriptLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    LuaScriptQuery,
+    LuaScriptQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<LuaScriptQuery, LuaScriptQueryVariables>(
+    LuaScriptDocument,
+    options
+  );
+}
+export type LuaScriptQueryHookResult = ReturnType<typeof useLuaScriptQuery>;
+export type LuaScriptLazyQueryHookResult = ReturnType<
+  typeof useLuaScriptLazyQuery
+>;
+export type LuaScriptQueryResult = Apollo.QueryResult<
+  LuaScriptQuery,
+  LuaScriptQueryVariables
 >;
 export const MulticastDnsMonitorUpdatesDocument = gql`
   subscription multicastDnsMonitorUpdates {

--- a/src/ui/gql/queries/luaScript.graphql
+++ b/src/ui/gql/queries/luaScript.graphql
@@ -1,0 +1,21 @@
+query luaScript(
+  $source: FirmwareSource!,
+  $gitTag: String!,
+  $gitBranch: String!,
+  $gitCommit: String!,
+  $localPath: String!,
+  $gitPullRequest: PullRequestInput,
+  $gitRepository: GitRepositoryInput!,
+) {
+  luaScript(
+    source: $source,
+    gitTag: $gitTag,
+    gitBranch: $gitBranch,
+    gitCommit: $gitCommit,
+    localPath: $localPath,
+    gitPullRequest: $gitPullRequest,
+    gitRepository: $gitRepository,
+  ) {
+    fileLocation
+  }
+}

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -990,14 +990,20 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
                       Back
                     </Button>
 
-                    <Button
-                      sx={styles.button}
-                      size="large"
-                      variant="contained"
-                      onClick={onBuildAndFlash}
-                    >
-                      Retry
-                    </Button>
+                    {!response?.buildFlashFirmware.success && (
+                      <Button
+                        sx={styles.button}
+                        size="large"
+                        variant="contained"
+                        onClick={
+                          currentJobType === BuildJobType.Build
+                            ? onBuild
+                            : onBuildAndFlash
+                        }
+                      >
+                        Retry
+                      </Button>
+                    )}
 
                     {response?.buildFlashFirmware.success &&
                       luaDownloadButton()}


### PR DESCRIPTION
- Update the Lua script location logic to choose the latest version of the Lua script from the selected firmware source
- Make the Lua download button more visible by changing it to a contained button and also showing the button after a successful build of a TX firmware along with a notification message telling the user to update their Lua script #99
![image](https://user-images.githubusercontent.com/38869875/140651870-76f9e8bd-ff5a-4bff-a595-113f035de20d.png)
![image](https://user-images.githubusercontent.com/38869875/140651938-f7b28c1a-4bcb-40b1-ae51-235c201ef1c2.png)

- Only show the retry button on an unsuccessful build and also make it retry the build type that was previously attempted instead of always executing build and flash.
- Update the build error message styling to make it more readable by specifying pre-wrap and using a monospace font family.  
![image](https://user-images.githubusercontent.com/38869875/140652038-ff47fd04-0c72-477c-aee1-5ec0c3a71247.png)
