### PR TITLE
Store regulatory domain and WIFI settings at the global scope

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1477,6 +1477,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "optionGroup",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "UserDefineOptionGroup",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1516,6 +1528,23 @@
           },
           {
             "name": "Enum",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "UserDefineOptionGroup",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "RegulatoryDomain900",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/api/src/factories/TargetUserDefinesFactory.ts
+++ b/src/api/src/factories/TargetUserDefinesFactory.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Service } from 'typedi';
 import UserDefineKey from '../library/FirmwareBuilder/Enum/UserDefineKey';
+import UserDefineOptionGroup from '../models/enum/UserDefineOptionGroup';
 import UserDefine from '../models/UserDefine';
 import DeviceService from '../services/Device';
 
@@ -21,17 +22,33 @@ export default class TargetUserDefinesFactory {
             return UserDefine.Text(UserDefineKey.BINDING_PHRASE, '', true);
           // Regulatory domains
           case UserDefineKey.REGULATORY_DOMAIN_AU_915:
-            return UserDefine.Boolean(UserDefineKey.REGULATORY_DOMAIN_AU_915);
+            return UserDefine.Boolean(
+              UserDefineKey.REGULATORY_DOMAIN_AU_915,
+              false,
+              UserDefineOptionGroup.RegulatoryDomain900
+            );
           case UserDefineKey.REGULATORY_DOMAIN_EU_868:
-            return UserDefine.Boolean(UserDefineKey.REGULATORY_DOMAIN_EU_868);
+            return UserDefine.Boolean(
+              UserDefineKey.REGULATORY_DOMAIN_EU_868,
+              false,
+              UserDefineOptionGroup.RegulatoryDomain900
+            );
           case UserDefineKey.REGULATORY_DOMAIN_IN_866:
-            return UserDefine.Boolean(UserDefineKey.REGULATORY_DOMAIN_IN_866);
+            return UserDefine.Boolean(
+              UserDefineKey.REGULATORY_DOMAIN_IN_866,
+              false,
+              UserDefineOptionGroup.RegulatoryDomain900
+            );
           case UserDefineKey.REGULATORY_DOMAIN_AU_433:
             return UserDefine.Boolean(UserDefineKey.REGULATORY_DOMAIN_AU_433);
           case UserDefineKey.REGULATORY_DOMAIN_EU_433:
             return UserDefine.Boolean(UserDefineKey.REGULATORY_DOMAIN_EU_433);
           case UserDefineKey.REGULATORY_DOMAIN_FCC_915:
-            return UserDefine.Boolean(UserDefineKey.REGULATORY_DOMAIN_FCC_915);
+            return UserDefine.Boolean(
+              UserDefineKey.REGULATORY_DOMAIN_FCC_915,
+              false,
+              UserDefineOptionGroup.RegulatoryDomain900
+            );
           case UserDefineKey.REGULATORY_DOMAIN_ISM_2400:
             return UserDefine.Boolean(
               UserDefineKey.REGULATORY_DOMAIN_ISM_2400,

--- a/src/api/src/models/UserDefine.ts
+++ b/src/api/src/models/UserDefine.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from 'type-graphql';
 import UserDefineKind from './enum/UserDefineKind';
 import UserDefineKey from '../library/FirmwareBuilder/Enum/UserDefineKey';
+import UserDefineOptionGroup from './enum/UserDefineOptionGroup';
 
 @ObjectType('UserDefine')
 export default class UserDefine {
@@ -19,12 +20,16 @@ export default class UserDefine {
   @Field({ nullable: true })
   value?: string;
 
+  @Field(() => UserDefineOptionGroup, { nullable: true })
+  optionGroup?: UserDefineOptionGroup;
+
   constructor(
     type: UserDefineKind,
     key: UserDefineKey,
     enabled = false,
     value = '',
-    enumValues?: string[]
+    enumValues?: string[],
+    optionGroup?: UserDefineOptionGroup
   ) {
     this.type = type;
 
@@ -46,10 +51,22 @@ export default class UserDefine {
     this.enumValues = enumValues;
     this.value = value;
     this.enabled = enabled;
+    this.optionGroup = optionGroup;
   }
 
-  static Boolean(key: UserDefineKey, enabled = false): UserDefine {
-    return new UserDefine(UserDefineKind.Boolean, key, enabled);
+  static Boolean(
+    key: UserDefineKey,
+    enabled = false,
+    userDefineOptionGroup?: UserDefineOptionGroup
+  ): UserDefine {
+    return new UserDefine(
+      UserDefineKind.Boolean,
+      key,
+      enabled,
+      undefined,
+      undefined,
+      userDefineOptionGroup
+    );
   }
 
   static Text(key: UserDefineKey, value = '', enabled = false): UserDefine {

--- a/src/api/src/models/enum/UserDefineOptionGroup.tsx
+++ b/src/api/src/models/enum/UserDefineOptionGroup.tsx
@@ -1,0 +1,11 @@
+import { registerEnumType } from 'type-graphql';
+
+enum UserDefineOptionGroup {
+  RegulatoryDomain900,
+}
+
+registerEnumType(UserDefineOptionGroup, {
+  name: 'UserDefineOptionGroup',
+});
+
+export default UserDefineOptionGroup;

--- a/src/ui/components/DeviceOptionsForm/index.tsx
+++ b/src/ui/components/DeviceOptionsForm/index.tsx
@@ -167,6 +167,18 @@ const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
           ...data,
         };
       }
+      // if part of the same optionGroup as the item being updated, disable it.
+      if (
+        data.enabled &&
+        data.optionGroup &&
+        data.optionGroup === opt.optionGroup
+      ) {
+        return {
+          ...opt,
+          enabled: false,
+        };
+      }
+
       return opt;
     });
     onChange({

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -191,12 +191,17 @@ export type UserDefine = {
   readonly enabled: Scalars['Boolean'];
   readonly enumValues?: Maybe<ReadonlyArray<Scalars['String']>>;
   readonly value?: Maybe<Scalars['String']>;
+  readonly optionGroup?: Maybe<UserDefineOptionGroup>;
 };
 
 export enum UserDefineKind {
   Boolean = 'Boolean',
   Text = 'Text',
   Enum = 'Enum',
+}
+
+export enum UserDefineOptionGroup {
+  RegulatoryDomain900 = 'RegulatoryDomain900',
 }
 
 export type Release = {
@@ -577,7 +582,7 @@ export type TargetDeviceOptionsQuery = { readonly __typename?: 'Query' } & {
   readonly targetDeviceOptions: ReadonlyArray<
     { readonly __typename?: 'UserDefine' } & Pick<
       UserDefine,
-      'type' | 'key' | 'enabled' | 'enumValues' | 'value'
+      'type' | 'key' | 'enabled' | 'enumValues' | 'value' | 'optionGroup'
     >
   >;
 };
@@ -1302,6 +1307,7 @@ export const TargetDeviceOptionsDocument = gql`
       enabled
       enumValues
       value
+      optionGroup
     }
   }
 `;

--- a/src/ui/gql/queries/deviceOptions.graphql
+++ b/src/ui/gql/queries/deviceOptions.graphql
@@ -23,5 +23,6 @@ query targetDeviceOptions(
     enabled
     enumValues
     value
+    optionGroup
   }
 }

--- a/src/ui/storage/commands/mergeWithDeviceOptionsFromStorage.ts
+++ b/src/ui/storage/commands/mergeWithDeviceOptionsFromStorage.ts
@@ -1,4 +1,8 @@
-import { UserDefine, UserDefineKey } from '../../gql/generated/types';
+import {
+  UserDefineOptionGroup,
+  UserDefine,
+  UserDefineKey,
+} from '../../gql/generated/types';
 import { DeviceOptions, IApplicationStorage } from '../index';
 
 const mergeWithDeviceOptionsFromStorage = async (
@@ -10,6 +14,10 @@ const mergeWithDeviceOptionsFromStorage = async (
   const savedTargetOptions = device
     ? await storage.getDeviceOptions(device)
     : null;
+  const wifiSSID = await storage.getWifiSSID();
+  const wifiPassword = await storage.getWifiPassword();
+  const regulatoryDomain900 = await storage.getRegulatoryDomain900();
+
   const addOverrides = (deviceOption: UserDefine): UserDefine => {
     if (
       deviceOption.key === UserDefineKey.BINDING_PHRASE &&
@@ -18,6 +26,32 @@ const mergeWithDeviceOptionsFromStorage = async (
       return {
         ...deviceOption,
         value: savedBindingPhrase,
+      };
+    }
+    if (
+      deviceOption.key === UserDefineKey.HOME_WIFI_SSID &&
+      wifiSSID.length > 0
+    ) {
+      return {
+        ...deviceOption,
+        value: wifiSSID,
+      };
+    }
+    if (
+      deviceOption.key === UserDefineKey.HOME_WIFI_PASSWORD &&
+      wifiPassword.length > 0
+    ) {
+      return {
+        ...deviceOption,
+        value: wifiPassword,
+      };
+    }
+    if (
+      deviceOption.optionGroup === UserDefineOptionGroup.RegulatoryDomain900
+    ) {
+      return {
+        ...deviceOption,
+        enabled: deviceOption.key === regulatoryDomain900,
       };
     }
     return deviceOption;

--- a/src/ui/storage/commands/persistDeviceOptions.ts
+++ b/src/ui/storage/commands/persistDeviceOptions.ts
@@ -1,4 +1,7 @@
-import { UserDefineKey } from '../../gql/generated/types';
+import {
+  UserDefineOptionGroup,
+  UserDefineKey,
+} from '../../gql/generated/types';
 import { DeviceOptions, IApplicationStorage } from '../index';
 
 const persistDeviceOptions = async (
@@ -9,17 +12,42 @@ const persistDeviceOptions = async (
   if (deviceOptions !== null) {
     await storage.saveDeviceOptions(device, deviceOptions);
 
-    const bindingPhrase = deviceOptions.userDefineOptions.find(
-      ({ key }) => key === UserDefineKey.BINDING_PHRASE
+    await Promise.all(
+      deviceOptions.userDefineOptions.map(async (userDefine) => {
+        if (userDefine.key === UserDefineKey.BINDING_PHRASE) {
+          if (
+            userDefine.enabled &&
+            userDefine.value &&
+            userDefine.value?.length > 0
+          ) {
+            await storage.setBindingPhrase(userDefine.value);
+          }
+        } else if (userDefine.key === UserDefineKey.HOME_WIFI_SSID) {
+          if (
+            userDefine.enabled &&
+            userDefine.value &&
+            userDefine.value?.length > 0
+          ) {
+            await storage.setWifiSSID(userDefine.value);
+          }
+        } else if (userDefine.key === UserDefineKey.HOME_WIFI_PASSWORD) {
+          if (
+            userDefine.enabled &&
+            userDefine.value &&
+            userDefine.value?.length > 0
+          ) {
+            await storage.setWifiPassword(userDefine.value);
+          }
+        } else if (
+          userDefine.optionGroup &&
+          userDefine.optionGroup ===
+            UserDefineOptionGroup.RegulatoryDomain900 &&
+          userDefine.enabled
+        ) {
+          await storage.setRegulatoryDomain900(userDefine.key);
+        }
+      })
     );
-    if (
-      bindingPhrase !== undefined &&
-      bindingPhrase.enabled &&
-      bindingPhrase.value &&
-      bindingPhrase.value?.length > 0
-    ) {
-      await storage.setBindingPhrase(bindingPhrase.value);
-    }
   }
 };
 

--- a/src/ui/storage/index.ts
+++ b/src/ui/storage/index.ts
@@ -1,6 +1,7 @@
 import {
   FirmwareVersionDataInput,
   UserDefine,
+  UserDefineKey,
   UserDefinesMode,
 } from '../gql/generated/types';
 import GitRepository from '../models/GitRepository';
@@ -37,12 +38,24 @@ export interface IApplicationStorage {
   getShowPreReleases(defaultValue: boolean): Promise<boolean>;
 
   setShowPreReleases(value: boolean): Promise<void>;
+
+  setWifiSSID(value: string): Promise<void>;
+  getWifiSSID(): Promise<string>;
+
+  setWifiPassword(value: string): Promise<void>;
+  getWifiPassword(): Promise<string>;
+
+  setRegulatoryDomain900(value: UserDefineKey): Promise<void>;
+  getRegulatoryDomain900(): Promise<UserDefineKey | null>;
 }
 
 const DEVICE_OPTIONS_BY_TARGET_KEYSPACE = 'device_options';
 const BINDING_PHRASE_KEY = 'binding_phrase';
 const FIRMWARE_SOURCE_KEY = 'firmware_source';
 const UI_SHOW_FIRMWARE_PRE_RELEASES = 'ui_show_pre_releases';
+const WIFI_SSID_KEY = 'wifi_ssid';
+const WIFI_PASSWORD_KEY = 'wifi_password';
+const REGULATORY_DOMAIN_900_KEY = 'regulatory_domain_900';
 
 export default class ApplicationStorage implements IApplicationStorage {
   async saveDeviceOptions(
@@ -128,5 +141,40 @@ export default class ApplicationStorage implements IApplicationStorage {
 
   async setShowPreReleases(value: boolean): Promise<void> {
     localStorage.setItem(UI_SHOW_FIRMWARE_PRE_RELEASES, JSON.stringify(value));
+  }
+
+  async setWifiSSID(bindingPhrase: string): Promise<void> {
+    localStorage.setItem(WIFI_SSID_KEY, bindingPhrase);
+  }
+
+  async getWifiSSID(): Promise<string> {
+    const value = localStorage.getItem(WIFI_SSID_KEY);
+    if (value === null) {
+      return '';
+    }
+    return value;
+  }
+
+  async setWifiPassword(bindingPhrase: string): Promise<void> {
+    localStorage.setItem(WIFI_PASSWORD_KEY, bindingPhrase);
+  }
+
+  async getWifiPassword(): Promise<string> {
+    const value = localStorage.getItem(WIFI_PASSWORD_KEY);
+    if (value === null) {
+      return '';
+    }
+    return value;
+  }
+
+  async setRegulatoryDomain900(bindingPhrase: UserDefineKey): Promise<void> {
+    localStorage.setItem(REGULATORY_DOMAIN_900_KEY, bindingPhrase);
+  }
+
+  async getRegulatoryDomain900(): Promise<UserDefineKey | null> {
+    const value = localStorage.getItem(
+      REGULATORY_DOMAIN_900_KEY
+    ) as UserDefineKey;
+    return value;
   }
 }


### PR DESCRIPTION
- Store WIFI settings at the global scope
- Store regulatory domain at the global scope.

To assist in the identification of the 900 MHz regulatory domains, a new property, UserDefineOptionGroup, was added to the UserDefine class to allow the grouping of the options.  The UI was also updated so that only one option in a UserDefineOptionGroup can be selected at a time.

Closes #91 