### PR TITLE
Merge network device options with default options

### DIFF
--- a/src/api/src/services/MulticastDns/index.ts
+++ b/src/api/src/services/MulticastDns/index.ts
@@ -90,7 +90,7 @@ export default class MulticastDnsService {
       if (userDefineKey) {
         if (match.length === 3) {
           if (match[2]) {
-            userDefines.push(UserDefine.Text(userDefineKey, match[2]));
+            userDefines.push(UserDefine.Text(userDefineKey, match[2], true));
           } else {
             userDefines.push(UserDefine.Boolean(userDefineKey, true));
           }

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -118,8 +118,8 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                 <ListItem sx={styles.complimentaryItem}>
                   <TextField
                     size="small"
-                    onBlur={onUserDefineValueChange(item.key)}
-                    defaultValue={item.value}
+                    onChange={onUserDefineValueChange(item.key)}
+                    value={item.value}
                     fullWidth
                     label={inputLabel(item.key)}
                   />

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -361,6 +361,26 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
             userDefineOptions: [...deviceOptionsResponse.targetDeviceOptions],
           }
         );
+
+        // if a network device is selected, merge in its options
+        if (selectedDevice && networkDevices.has(selectedDevice)) {
+          const networkDevice = networkDevices.get(selectedDevice);
+          userDefineOptions.userDefineOptions = userDefineOptions.userDefineOptions.map(
+            (userDefineOption) => {
+              const networkDeviceOption = networkDevice?.options.find(
+                (item) => item.key === userDefineOption.key
+              );
+
+              const newUserDefineOption = { ...userDefineOption };
+              if (networkDeviceOption) {
+                newUserDefineOption.enabled = networkDeviceOption.enabled;
+                newUserDefineOption.value = networkDeviceOption.value;
+              }
+              return newUserDefineOption;
+            }
+          );
+        }
+
         setDeviceOptionsFormData(userDefineOptions);
       };
       handleUpdate().catch((err) => {


### PR DESCRIPTION
When a network device is selected, merge its options with the default options.  This will set items like the binding phrase to the devices binding phrase and check any options that were previously selected.  This change will NOT unselect options, since not all user defines are included in the options list received via mDNS, it will only select options that were disabled by default.