### PR TITLE
Add support for URLs based on selected release version

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -104,7 +104,7 @@
         "HOME_WIFI_PASSWORD",
         "UNLOCK_HIGHER_POWER"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-betafpv900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-betafpv900/",
       "deviceType": "ExpressLRS",
       "aliases": [
         {
@@ -148,7 +148,7 @@
         "HOME_WIFI_PASSWORD",
         "UNLOCK_HIGHER_POWER"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-betafpv900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-betafpv900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -186,7 +186,7 @@
         "RCVR_UART_BAUD",
         "RCVR_INVERT_TX"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-betafpv900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-betafpv900/",
       "deviceType": "ExpressLRS",
       "aliases": [
         {
@@ -228,7 +228,7 @@
         "WS2812_IS_GRB",
         "UNLOCK_HIGHER_POWER"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-betafpv2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-betafpv2400/",
       "deviceType": "ExpressLRS",
       "aliases": [
         {
@@ -270,7 +270,7 @@
         "WS2812_IS_GRB",
         "UNLOCK_HIGHER_POWER"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-betafpv2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-betafpv2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -306,7 +306,7 @@
         "RCVR_UART_BAUD",
         "RCVR_INVERT_TX"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-betafpv2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-betafpv2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -342,7 +342,7 @@
         "RCVR_UART_BAUD",
         "RCVR_INVERT_TX"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-matek2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-matek2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -414,7 +414,7 @@
         "UNLOCK_HIGHER_POWER",
         "USE_TX_BACKPACK"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-r9m/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-r9m/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -448,7 +448,7 @@
         "DISABLE_ALL_BEEPS",
         "USE_DYNAMIC_POWER"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-r9m/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-r9m/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -479,7 +479,7 @@
         "DISABLE_ALL_BEEPS",
         "USE_DYNAMIC_POWER"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-r9m/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-r9m/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -509,7 +509,7 @@
         "USE_R9MM_R9MINI_SBUS",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-r9receivers/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-r9receivers/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -539,7 +539,7 @@
         "USE_DIVERSITY",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-r9receivers/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-r9receivers/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -568,7 +568,7 @@
         "LOCK_ON_FIRST_CONNECTION",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-r9receivers/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-r9receivers/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -598,7 +598,7 @@
         "USE_DIVERSITY",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-r9receivers/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-r9receivers/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -627,7 +627,7 @@
         "LOCK_ON_FIRST_CONNECTION",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-r9receivers/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-r9receivers/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -656,7 +656,7 @@
         "LOCK_ON_FIRST_CONNECTION",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-jumper900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-jumper900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -691,7 +691,7 @@
         "USE_DYNAMIC_POWER",
         "WS2812_IS_GRB"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-es24tx/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-es24tx/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -726,7 +726,7 @@
         "USE_DYNAMIC_POWER",
         "WS2812_IS_GRB"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-es24tx/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-es24tx/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -761,7 +761,7 @@
         "USE_DYNAMIC_POWER",
         "WS2812_IS_GRB"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-es24tx/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-es24tx/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -798,7 +798,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-es900tx/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-es900tx/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -836,7 +836,7 @@
         "RCVR_UART_BAUD",
         "RCVR_INVERT_TX"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-hmes900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-hmes900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -871,7 +871,7 @@
         "RCVR_UART_BAUD",
         "RCVR_INVERT_TX"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-hmep2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-hmep2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -897,7 +897,7 @@
         "USE_500HZ",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-hmpp2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-hmpp2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -941,7 +941,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-es900tx/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-es900tx/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -970,7 +970,7 @@
         "LOCK_ON_FIRST_CONNECTION",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-hmes900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-hmes900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1127,7 +1127,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-diy900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1173,7 +1173,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-diy900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1207,7 +1207,7 @@
         "HOME_WIFI_PASSWORD",
         "UNLOCK_HIGHER_POWER"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-diy900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1240,7 +1240,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-diy900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1278,7 +1278,7 @@
         "RCVR_UART_BAUD",
         "RCVR_INVERT_TX"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-diyreceivers900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-diyreceivers900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1310,7 +1310,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-diyreceivers900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-diyreceivers900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1341,7 +1341,7 @@
         "USE_DYNAMIC_POWER",
         "WS2812_IS_GRB"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-diy/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1377,7 +1377,7 @@
         "USE_DYNAMIC_POWER",
         "WS2812_IS_GRB"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-diy/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1408,7 +1408,7 @@
         "USE_DYNAMIC_POWER",
         "WS2812_IS_GRB"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-diy/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1441,7 +1441,7 @@
         "DISABLE_ALL_BEEPS",
         "MY_STARTUP_MELODY"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-ghost2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-ghost2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1474,7 +1474,7 @@
         "DISABLE_ALL_BEEPS",
         "MY_STARTUP_MELODY"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-ghost2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-ghost2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1500,7 +1500,7 @@
         "USE_500HZ",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-ghost2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-ghost2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1536,7 +1536,7 @@
         "RCVR_UART_BAUD",
         "RCVR_INVERT_TX"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-diyreceivers/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-diyreceivers/",
       "deviceType": "ExpressLRS",
       "aliases": [
         {
@@ -1606,7 +1606,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-diyreceivers/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-diyreceivers/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1632,7 +1632,7 @@
         "USE_500HZ",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-diyreceivers/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-diyreceivers/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1666,7 +1666,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-voyager900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-voyager900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1700,7 +1700,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-voyager900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-voyager900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1729,7 +1729,7 @@
         "LOCK_ON_FIRST_CONNECTION",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-voyager900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-voyager900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1767,7 +1767,7 @@
         "RCVR_UART_BAUD",
         "RCVR_INVERT_TX"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-voyager900/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-voyager900/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1801,7 +1801,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-flash2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-flash2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1835,7 +1835,7 @@
         "HOME_WIFI_SSID",
         "HOME_WIFI_PASSWORD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-flash2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-flash2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1861,7 +1861,7 @@
         "USE_500HZ",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-flash2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-flash2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1897,7 +1897,7 @@
         "RCVR_UART_BAUD",
         "RCVR_INVERT_TX"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-flash2400/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-flash2400/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1927,7 +1927,7 @@
         "UART_INVERTED",
         "USE_DYNAMIC_POWER"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/tx-siyifm30/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-siyifm30/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1954,7 +1954,7 @@
         "USE_DIVERSITY",
         "RCVR_UART_BAUD"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-siyiFRmini/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-siyiFRmini/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },
@@ -1984,7 +1984,7 @@
         "UART_INVERTED",
         "USE_DYNAMIC_POWER"
       ],
-      "wikiUrl": "https://www.expresslrs.org/release/quick-start/rx-siyiFRmini/",
+      "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-siyiFRmini/",
       "deviceType": "ExpressLRS",
       "aliases": []
     },

--- a/src/ui/components/DeviceOptionsForm/index.tsx
+++ b/src/ui/components/DeviceOptionsForm/index.tsx
@@ -12,6 +12,7 @@ import {
 import React, { FunctionComponent } from 'react';
 import UserDefinesList from '../UserDefinesList';
 import {
+  FirmwareVersionDataInput,
   UserDefine,
   UserDefineKey,
   UserDefinesMode,
@@ -49,6 +50,7 @@ interface DeviceOptionsFormProps {
   target: string | null;
   deviceOptions: DeviceOptionsFormData;
   onChange: (data: DeviceOptionsFormData) => void;
+  firmwareVersionData: FirmwareVersionDataInput | null;
 }
 
 enum UserDefineCategory {
@@ -158,7 +160,7 @@ const userDefinesToCategories = (
 const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
   props
 ) => {
-  const { target, deviceOptions, onChange } = props;
+  const { target, deviceOptions, onChange, firmwareVersionData } = props;
   const categories = userDefinesToCategories(deviceOptions.userDefineOptions);
 
   const onOptionUpdate = (data: UserDefine) => {
@@ -265,6 +267,7 @@ const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
                     <UserDefinesList
                       options={categories[UserDefineCategory.RegulatoryDomains]}
                       onChange={onOptionUpdate}
+                      firmwareVersionData={firmwareVersionData}
                     />
                   </>
                 )}
@@ -274,6 +277,7 @@ const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
                     <UserDefinesList
                       options={categories[UserDefineCategory.BindingPhrase]}
                       onChange={onOptionUpdate}
+                      firmwareVersionData={firmwareVersionData}
                     />
                   </>
                 )}
@@ -286,6 +290,7 @@ const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
                         categories[UserDefineCategory.CompatibilityOptions]
                       }
                       onChange={onOptionUpdate}
+                      firmwareVersionData={firmwareVersionData}
                     />
                   </>
                 )}
@@ -301,6 +306,7 @@ const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
                         categories[UserDefineCategory.PerformanceOptions]
                       }
                       onChange={onOptionUpdate}
+                      firmwareVersionData={firmwareVersionData}
                     />
                   </>
                 )}
@@ -310,6 +316,7 @@ const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
                     <UserDefinesList
                       options={categories[UserDefineCategory.ExtraData]}
                       onChange={onOptionUpdate}
+                      firmwareVersionData={firmwareVersionData}
                     />
                   </>
                 )}
@@ -319,6 +326,7 @@ const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
                     <UserDefinesList
                       options={categories[UserDefineCategory.NetworkOptions]}
                       onChange={onOptionUpdate}
+                      firmwareVersionData={firmwareVersionData}
                     />
                   </>
                 )}
@@ -328,6 +336,7 @@ const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
                     <UserDefinesList
                       options={categories[UserDefineCategory.OtherOptions]}
                       onChange={onOptionUpdate}
+                      firmwareVersionData={firmwareVersionData}
                     />
                   </>
                 )}

--- a/src/ui/components/DeviceTargetForm/index.tsx
+++ b/src/ui/components/DeviceTargetForm/index.tsx
@@ -7,7 +7,11 @@ import React, {
 } from 'react';
 import { Box } from '@mui/material';
 import Omnibox from '../Omnibox';
-import { Device, Target } from '../../gql/generated/types';
+import {
+  Device,
+  FirmwareVersionDataInput,
+  Target,
+} from '../../gql/generated/types';
 import FlashingMethodOptions from '../FlashingMethodOptions';
 
 const styles = {
@@ -20,12 +24,13 @@ interface FirmwareVersionCardProps {
   currentTarget: Target | null;
   onChange: (data: Target | null) => void;
   targetOptions: Device[] | null;
+  firmwareVersionData: FirmwareVersionDataInput | null;
 }
 
 const DeviceTargetForm: FunctionComponent<FirmwareVersionCardProps> = (
   props
 ) => {
-  const { onChange, currentTarget, targetOptions } = props;
+  const { onChange, currentTarget, targetOptions, firmwareVersionData } = props;
 
   interface Dictionary<T> {
     [Key: string]: T;
@@ -193,6 +198,7 @@ const DeviceTargetForm: FunctionComponent<FirmwareVersionCardProps> = (
                 selectedDeviceValue
               ] ?? null
             }
+            firmwareVersionData={firmwareVersionData}
           />
         )}
     </>

--- a/src/ui/components/FlashingMethodDescription/index.tsx
+++ b/src/ui/components/FlashingMethodDescription/index.tsx
@@ -1,7 +1,12 @@
 import React, { FunctionComponent, memo } from 'react';
 import { Box, Tooltip } from '@mui/material';
 import QuestionIcon from '@mui/icons-material/Help';
-import { FlashingMethod } from '../../gql/generated/types';
+import semver from 'semver';
+import {
+  FirmwareSource,
+  FirmwareVersionDataInput,
+  FlashingMethod,
+} from '../../gql/generated/types';
 
 const styles = {
   root: {
@@ -14,196 +19,221 @@ const styles = {
   },
 };
 
+const urlVersioning = (
+  firmwareVersionData: FirmwareVersionDataInput | null,
+  url: string
+): string => {
+  if (
+    firmwareVersionData &&
+    firmwareVersionData.source === FirmwareSource.GitTag &&
+    firmwareVersionData.gitTag &&
+    semver.major(firmwareVersionData.gitTag) > 0
+  ) {
+    const majorVersion = semver.major(firmwareVersionData.gitTag);
+    return url.replace('{version}', `${majorVersion}.0`);
+  }
+  return url.replace('{version}', 'release');
+};
+
 interface FlashingMethodDescriptionProps {
   flashingMethod: FlashingMethod;
   deviceWikiUrl: string | null;
+  firmwareVersionData: FirmwareVersionDataInput | null;
 }
 
-const FlashingMethodDescription: FunctionComponent<FlashingMethodDescriptionProps> = memo(
-  ({ flashingMethod, deviceWikiUrl }) => {
-    const wikiUrl = (deviceWikiUrl ?? '').length > 0 ? deviceWikiUrl : null;
-    const toText = (key: FlashingMethod) => {
-      switch (key) {
-        case FlashingMethod.BetaflightPassthrough:
-          return (
-            <div>
-              <p>
-                This method allows you to flash your receiver while it is
-                connected to your flight controller by using the passthrough
-                feature of the flight controller.
-              </p>
-              <ol>
-                <li>
-                  Plug in your FC to your computer, but do NOT connect to
-                  betaflight configurator.
-                </li>
-                <li>
-                  Select your desired Device Options and your flight controllers
-                  serial device below.
-                </li>
-                <li>Run Build & Flash</li>
-              </ol>
-              <p>
-                <a
-                  target="_blank"
-                  rel="noreferrer noreferrer"
-                  href={
-                    wikiUrl ??
-                    'https://www.expresslrs.org/release/software/updating/betaflight-passthrough/'
-                  }
-                >
-                  Check our Wiki page for information.
-                </a>
-              </p>
-            </div>
-          );
-        case FlashingMethod.Radio:
-          return (
-            <div>
-              <p>
-                This method allows you to build the firmware which can then be
-                copied to your radio and flashed to the transmitter using
-                EdgeTX/OpenTX
-              </p>
-              <ol>
-                <li>Run Build</li>
-                <li>
-                  Put the firmware on your radio&apos;s SD Card (recommended
-                  location is inside the /FIRMWARE folder)
-                </li>
-                <li>
-                  On your radio, navigate to where the firmware file was placed
-                  (/FIRMWARE), select the firmware file, click-hold the Enter
-                  button and select &quot;Flash External ELRS&quot;
-                </li>
-              </ol>
-            </div>
-          );
-        case FlashingMethod.DFU:
-          return (
-            <div>
-              <p>
-                This method allows you to flash your receiver or transmitter via
-                the Devices Firmware Upgrade mode.
-              </p>
-              <p>
-                <a
-                  target="_blank"
-                  rel="noreferrer noreferrer"
-                  href={
-                    wikiUrl ??
-                    'https://www.expresslrs.org/release/quick-start/getting-started/'
-                  }
-                >
-                  Check the Wiki page for your particular device for more
-                  information.
-                </a>
-              </p>
-            </div>
-          );
-        case FlashingMethod.STLink:
-          return (
-            <div>
-              <p>
-                This method allows you to flash your receiver or transmitter
-                using an STLink programmer connected to the device.
-              </p>
-              <p>
-                <a
-                  target="_blank"
-                  rel="noreferrer noreferrer"
-                  href={
-                    wikiUrl ??
-                    'https://www.expresslrs.org/release/quick-start/getting-started/'
-                  }
-                >
-                  Check the Wiki page for your particular device for more
-                  information.
-                </a>
-              </p>
-            </div>
-          );
-        case FlashingMethod.Stock_BL:
-          return (
-            <div>
-              <p>
-                This method allows you to flash your receiver or transmitter
-                using the bootloader on the device.
-              </p>
-              <p>
-                <a
-                  target="_blank"
-                  rel="noreferrer noreferrer"
-                  href={
-                    wikiUrl ??
-                    'https://www.expresslrs.org/release/quick-start/getting-started/'
-                  }
-                >
-                  Check the Wiki page for your particular device for more
-                  information.
-                </a>
-              </p>
-            </div>
-          );
-        case FlashingMethod.UART:
-          return (
-            <div>
-              <p>
-                This method allows you to flash your receiver or transmitter via
-                its USB port or wiring up an FTDI device.
-              </p>
-              <p>
-                <a
-                  target="_blank"
-                  rel="noreferrer noreferrer"
-                  href={
-                    wikiUrl ??
-                    'https://www.expresslrs.org/release/quick-start/getting-started/'
-                  }
-                >
-                  Check the Wiki page for your particular device for more
-                  information.
-                </a>
-              </p>
-            </div>
-          );
-        case FlashingMethod.WIFI:
-          return (
-            <div>
-              <p>
-                This method creates a firmware file you can upload to your
-                receiver or transmitter by connecting to its built in wifi.
-              </p>
-              <p>
-                <a
-                  target="_blank"
-                  rel="noreferrer noreferrer"
-                  href={
-                    wikiUrl ??
-                    'https://www.expresslrs.org/release/quick-start/getting-started/'
-                  }
-                >
-                  Check the Wiki page for your particular device for more
-                  information.
-                </a>
-              </p>
-            </div>
-          );
-        default:
-          return '';
-      }
-    };
-    const desc = toText(flashingMethod);
-    return (
-      <Box sx={styles.root}>
-        {desc !== '' && (
-          <Tooltip placement="top" arrow title={<div>{desc}</div>}>
-            <QuestionIcon sx={styles.icon} />
-          </Tooltip>
-        )}
-      </Box>
-    );
-  }
-);
+const FlashingMethodDescription: FunctionComponent<FlashingMethodDescriptionProps> = ({
+  flashingMethod,
+  deviceWikiUrl,
+  firmwareVersionData,
+}) => {
+  const wikiUrl = (deviceWikiUrl ?? '').length > 0 ? deviceWikiUrl : null;
+  const toText = (key: FlashingMethod) => {
+    switch (key) {
+      case FlashingMethod.BetaflightPassthrough:
+        return (
+          <div>
+            <p>
+              This method allows you to flash your receiver while it is
+              connected to your flight controller by using the passthrough
+              feature of the flight controller.
+            </p>
+            <ol>
+              <li>
+                Plug in your FC to your computer, but do NOT connect to
+                betaflight configurator.
+              </li>
+              <li>
+                Select your desired Device Options and your flight controllers
+                serial device below.
+              </li>
+              <li>Run Build & Flash</li>
+            </ol>
+            <p>
+              <a
+                target="_blank"
+                rel="noreferrer noreferrer"
+                href={urlVersioning(
+                  firmwareVersionData,
+                  wikiUrl ??
+                    'https://www.expresslrs.org/{version}/software/updating/betaflight-passthrough/'
+                )}
+              >
+                Check our Wiki page for information.
+              </a>
+            </p>
+          </div>
+        );
+      case FlashingMethod.Radio:
+        return (
+          <div>
+            <p>
+              This method allows you to build the firmware which can then be
+              copied to your radio and flashed to the transmitter using
+              EdgeTX/OpenTX
+            </p>
+            <ol>
+              <li>Run Build</li>
+              <li>
+                Put the firmware on your radio&apos;s SD Card (recommended
+                location is inside the /FIRMWARE folder)
+              </li>
+              <li>
+                On your radio, navigate to where the firmware file was placed
+                (/FIRMWARE), select the firmware file, click-hold the Enter
+                button and select &quot;Flash External ELRS&quot;
+              </li>
+            </ol>
+          </div>
+        );
+      case FlashingMethod.DFU:
+        return (
+          <div>
+            <p>
+              This method allows you to flash your receiver or transmitter via
+              the Devices Firmware Upgrade mode.
+            </p>
+            <p>
+              <a
+                target="_blank"
+                rel="noreferrer noreferrer"
+                href={urlVersioning(
+                  firmwareVersionData,
+                  wikiUrl ??
+                    'https://www.expresslrs.org/{version}/quick-start/getting-started/'
+                )}
+              >
+                Check the Wiki page for your particular device for more
+                information.
+              </a>
+            </p>
+          </div>
+        );
+      case FlashingMethod.STLink:
+        return (
+          <div>
+            <p>
+              This method allows you to flash your receiver or transmitter using
+              an STLink programmer connected to the device.
+            </p>
+            <p>
+              <a
+                target="_blank"
+                rel="noreferrer noreferrer"
+                href={urlVersioning(
+                  firmwareVersionData,
+                  wikiUrl ??
+                    'https://www.expresslrs.org/{version}/quick-start/getting-started/'
+                )}
+              >
+                Check the Wiki page for your particular device for more
+                information.
+              </a>
+            </p>
+          </div>
+        );
+      case FlashingMethod.Stock_BL:
+        return (
+          <div>
+            <p>
+              This method allows you to flash your receiver or transmitter using
+              the bootloader on the device.
+            </p>
+            <p>
+              <a
+                target="_blank"
+                rel="noreferrer noreferrer"
+                href={urlVersioning(
+                  firmwareVersionData,
+                  wikiUrl ??
+                    'https://www.expresslrs.org/{version}/quick-start/getting-started/'
+                )}
+              >
+                Check the Wiki page for your particular device for more
+                information.
+              </a>
+            </p>
+          </div>
+        );
+      case FlashingMethod.UART:
+        return (
+          <div>
+            <p>
+              This method allows you to flash your receiver or transmitter via
+              its USB port or wiring up an FTDI device.
+            </p>
+            <p>
+              <a
+                target="_blank"
+                rel="noreferrer noreferrer"
+                href={urlVersioning(
+                  firmwareVersionData,
+                  wikiUrl ??
+                    'https://www.expresslrs.org/{version}/quick-start/getting-started/'
+                )}
+              >
+                Check the Wiki page for your particular device for more
+                information.
+              </a>
+            </p>
+          </div>
+        );
+      case FlashingMethod.WIFI:
+        return (
+          <div>
+            <p>
+              This method creates a firmware file you can upload to your
+              receiver or transmitter by connecting to its built in wifi.
+            </p>
+            <p>
+              <a
+                target="_blank"
+                rel="noreferrer noreferrer"
+                href={urlVersioning(
+                  firmwareVersionData,
+                  wikiUrl ??
+                    'https://www.expresslrs.org/{version}/quick-start/getting-started/'
+                )}
+              >
+                Check the Wiki page for your particular device for more
+                information.
+              </a>
+            </p>
+          </div>
+        );
+      default:
+        return '';
+    }
+  };
+  const desc = toText(flashingMethod);
+  return (
+    <Box sx={styles.root}>
+      {desc !== '' && (
+        <Tooltip placement="top" arrow title={<div>{desc}</div>}>
+          <QuestionIcon sx={styles.icon} />
+        </Tooltip>
+      )}
+    </Box>
+  );
+};
 
 export default FlashingMethodDescription;

--- a/src/ui/components/FlashingMethodOptions/index.tsx
+++ b/src/ui/components/FlashingMethodOptions/index.tsx
@@ -12,7 +12,11 @@ import React, {
   useEffect,
   useMemo,
 } from 'react';
-import { Device, Target } from '../../gql/generated/types';
+import {
+  Device,
+  FirmwareVersionDataInput,
+  Target,
+} from '../../gql/generated/types';
 import FlashingMethodDescription from '../FlashingMethodDescription';
 
 const styles = {
@@ -42,12 +46,13 @@ interface FlashingMethodsListProps {
   currentTarget: Target | null;
   currentDevice: Device | null;
   onChange: (data: Target | null) => void;
+  firmwareVersionData: FirmwareVersionDataInput | null;
 }
 
 const FlashingMethodOptions: FunctionComponent<FlashingMethodsListProps> = (
   props
 ) => {
-  const { onChange, currentTarget, currentDevice } = props;
+  const { onChange, currentTarget, currentDevice, firmwareVersionData } = props;
   const targetMappingsSorted = useMemo(
     () =>
       currentDevice?.targets
@@ -96,6 +101,7 @@ const FlashingMethodOptions: FunctionComponent<FlashingMethodsListProps> = (
             <FlashingMethodDescription
               flashingMethod={targetMapping.flashingMethod}
               deviceWikiUrl={currentDevice?.wikiUrl ?? null}
+              firmwareVersionData={firmwareVersionData}
             />
           )}
         </>

--- a/src/ui/components/UserDefineDescription/index.tsx
+++ b/src/ui/components/UserDefineDescription/index.tsx
@@ -1,7 +1,12 @@
 import React, { FunctionComponent, memo } from 'react';
 import { Box, Tooltip } from '@mui/material';
 import QuestionIcon from '@mui/icons-material/Help';
-import { UserDefineKey } from '../../gql/generated/types';
+import semver from 'semver';
+import {
+  FirmwareSource,
+  FirmwareVersionDataInput,
+  UserDefineKey,
+} from '../../gql/generated/types';
 
 const styles = {
   root: {
@@ -16,10 +21,27 @@ const styles = {
 
 interface UserDefineDescriptionProps {
   userDefine: UserDefineKey;
+  firmwareVersionData: FirmwareVersionDataInput | null;
 }
 
+const urlVersioning = (
+  firmwareVersionData: FirmwareVersionDataInput | null,
+  url: string
+): string => {
+  if (
+    firmwareVersionData &&
+    firmwareVersionData.source === FirmwareSource.GitTag &&
+    firmwareVersionData.gitTag &&
+    semver.major(firmwareVersionData.gitTag) > 0
+  ) {
+    const majorVersion = semver.major(firmwareVersionData.gitTag);
+    return url.replace('{version}', `${majorVersion}.0`);
+  }
+  return url.replace('{version}', 'release');
+};
+
 const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = memo(
-  ({ userDefine }) => {
+  ({ userDefine, firmwareVersionData }) => {
     const toText = (key: UserDefineKey) => {
       switch (key) {
         case UserDefineKey.REGULATORY_DOMAIN_AU_433:
@@ -45,7 +67,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#regulatory-domain"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#regulatory-domain'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -64,7 +89,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#regulatory-domain"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#regulatory-domain'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -87,7 +115,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#binding-phrase"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#binding-phrase'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -114,7 +145,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#performance-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#performance-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -134,7 +168,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -152,7 +189,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -176,7 +216,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -194,7 +237,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -209,7 +255,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#performance-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#performance-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -224,7 +273,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#performance-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#performance-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -259,7 +311,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/quick-start/tx-prep/"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/quick-start/tx-prep/'
+                  )}
                 >
                   radio setup page
                 </a>{' '}
@@ -267,7 +322,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#performance-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#performance-options'
+                  )}
                 >
                   Wiki page for latest definition
                 </a>
@@ -303,7 +361,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/quick-start/tx-prep/"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/quick-start/tx-prep/'
+                  )}
                 >
                   radio setup page
                 </a>{' '}
@@ -311,7 +372,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#performance-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#performance-options'
+                  )}
                 >
                   Wiki page for latest definition
                 </a>
@@ -362,7 +426,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#switches"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#switches'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -398,7 +465,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#telemetry"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#telemetry'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -429,7 +499,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#telemetry"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#telemetry'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -451,7 +524,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#performance-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#performance-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -470,7 +546,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#performance-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#performance-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -488,7 +567,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -503,7 +585,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -518,7 +603,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -577,7 +665,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -611,7 +702,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#performance-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#performance-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -636,7 +730,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/hardware/fan-mod/"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/hardware/fan-mod/'
+                  )}
                 >
                   R9M Fan Mod Cover
                 </a>
@@ -647,7 +744,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#output-power-limit"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#output-power-limit'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -667,7 +767,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#compatability-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#compatability-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -686,7 +789,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#compatability-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#compatability-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -708,7 +814,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#compatability-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#compatability-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -728,7 +837,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -762,7 +874,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/quick-start/tx-prep/"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/quick-start/tx-prep/'
+                  )}
                 >
                   radio setup page
                 </a>{' '}
@@ -770,7 +885,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#performance-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#performance-options'
+                  )}
                 >
                   Wiki page for latest definition
                 </a>
@@ -790,7 +908,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -810,7 +931,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -835,7 +959,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#compatability-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#compatability-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -859,7 +986,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#compatability-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#compatability-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -877,7 +1007,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>
@@ -895,7 +1028,10 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> = mem
                 <a
                   target="_blank"
                   rel="noreferrer noreferrer"
-                  href="https://www.expresslrs.org/release/software/user-defines/#other-options"
+                  href={urlVersioning(
+                    firmwareVersionData,
+                    'https://www.expresslrs.org/{version}/software/user-defines/#other-options'
+                  )}
                 >
                   Check our Wiki page for latest definition.
                 </a>

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -10,6 +10,7 @@ import {
   TextField,
 } from '@mui/material';
 import {
+  FirmwareVersionDataInput,
   UserDefine,
   UserDefineKey,
   UserDefineKind,
@@ -32,10 +33,11 @@ const styles = {
 interface UserDefinesListProps {
   options: UserDefine[];
   onChange: (data: UserDefine) => void;
+  firmwareVersionData: FirmwareVersionDataInput | null;
 }
 
 const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
-  const { options, onChange } = props;
+  const { options, onChange, firmwareVersionData } = props;
   const onChecked = (data: UserDefineKey) => {
     const opt = options.find(({ key }) => key === data);
     if (opt !== undefined) {
@@ -110,7 +112,10 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
               </ListItemIcon>
               <ListItemText>{item.key}</ListItemText>
               <ListItemSecondaryAction>
-                <UserDefineDescription userDefine={item.key} />
+                <UserDefineDescription
+                  userDefine={item.key}
+                  firmwareVersionData={firmwareVersionData}
+                />
               </ListItemSecondaryAction>
             </ListItem>
             {item.type === UserDefineKind.Text && item.enabled && (

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -800,6 +800,7 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
                     <DeviceTargetForm
                       currentTarget={deviceTarget}
                       onChange={onDeviceTarget}
+                      firmwareVersionData={firmwareVersionData}
                       targetOptions={deviceTargets}
                     />
                   )}
@@ -853,6 +854,7 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
                     <DeviceOptionsForm
                       target={deviceTarget?.name ?? null}
                       deviceOptions={deviceOptionsFormData}
+                      firmwareVersionData={firmwareVersionData}
                       onChange={onUserDefines}
                     />
                   )}


### PR DESCRIPTION
If {version} is found in the FlashingMethodDescription or UserDefineDescription URLs, then replace it with the selected firmware version (1.0, 2.0, etc.) or with "release" if a particular release version is not selected (Git Branch, Git Commit, etc.).