### PR TITLE
Add abbreviated name support to Device

### DIFF
--- a/devices/betafpv-2400.json
+++ b/devices/betafpv-2400.json
@@ -38,7 +38,8 @@
       {
         "category": "HiYOUNGER 2.4 GHz",
         "name": "HiYOUNGER TX2G4 2400 TX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER TX2G4"
       }
     ]
   },

--- a/devices/betafpv-900.json
+++ b/devices/betafpv-900.json
@@ -39,7 +39,8 @@
       {
         "category": "HiYOUNGER 900 MHz",
         "name": "HiYOUNGER 900 TX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER 900 TX"
       }
     ]
   },
@@ -121,7 +122,8 @@
       {
         "category": "HiYOUNGER 900 MHz",
         "name": "HiYOUNGER 900 RX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER 900 RX"
       }
     ]
   }

--- a/devices/diy-2400.json
+++ b/devices/diy-2400.json
@@ -139,42 +139,50 @@
       {
         "category": "Flywoo 2.4 GHz",
         "name": "Flywoo EL24E 2400 RX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "Flywoo EL24E"
       },
       {
         "category": "Flywoo 2.4 GHz",
         "name": "Flywoo EL24P 2400 RX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "Flywoo EL24P"
       },
       {
         "category": "HiYOUNGER 2.4 GHz",
         "name": "HiYOUNGER SP24S 2400 RX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER SP24S"
       },
       {
         "category": "HiYOUNGER 2.4 GHz",
         "name": "HiYOUNGER EP24S 2400 RX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER EP24S"
       },
       {
         "category": "HiYOUNGER 2.4 GHz",
         "name": "HiYOUNGER RX24T 2400 RX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER RX24T"
       },
       {
         "category": "JHEMCU 2.4 GHz",
         "name": "JHEMCU SP24S 2400 RX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "JHEMCU SP24S"
       },
       {
         "category": "JHEMCU 2.4 GHz",
         "name": "JHEMCU EP24S 2400 RX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "JHEMCU EP24S"
       },
       {
         "category": "JHEMCU 2.4 GHz",
         "name": "JHEMCU RX24T 2400 RX",
-        "wikiUrl": ""
+        "wikiUrl": "",
+        "abbreviatedName": "JHEMCU RX24T"
       }
     ]
   },

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -823,6 +823,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "abbreviatedName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/src/api/src/models/Device.ts
+++ b/src/api/src/models/Device.ts
@@ -29,6 +29,9 @@ export default class Device {
   @Field({ nullable: true })
   parent?: string | null;
 
+  @Field({ nullable: true })
+  abbreviatedName?: string | null;
+
   constructor(
     id: string,
     name: string,
@@ -37,7 +40,8 @@ export default class Device {
     userDefines: UserDefineKey[],
     deviceType: DeviceType,
     wikiUrl?: string,
-    parent?: string | null
+    parent?: string | null,
+    abbreviatedName?: string | null
   ) {
     this.id = id;
     this.name = name;
@@ -47,5 +51,6 @@ export default class Device {
     this.wikiUrl = wikiUrl;
     this.deviceType = deviceType;
     this.parent = parent;
+    this.abbreviatedName = abbreviatedName;
   }
 }

--- a/src/api/src/services/Device/index.ts
+++ b/src/api/src/services/Device/index.ts
@@ -112,13 +112,19 @@ export default class DeviceService implements IDevices {
           wikiUrl: value.wikiUrl,
           deviceType,
           parent: null,
+          abbreviatedName: value.abbreviatedName,
         };
 
         devices.push(device);
 
         if (value.aliases) {
           value.aliases.forEach(
-            (alias: { name: any; category: any; wikiUrl: any }) => {
+            (alias: {
+              name: any;
+              category: any;
+              wikiUrl: any;
+              abbreviatedName?: any;
+            }) => {
               devices.push({
                 id: alias.name,
                 name: alias.name,
@@ -134,11 +140,12 @@ export default class DeviceService implements IDevices {
                 wikiUrl: alias.wikiUrl,
                 deviceType: device.deviceType,
                 parent: device.id,
+                abbreviatedName: alias.abbreviatedName,
               });
             }
           );
         }
-      } catch (error) {
+      } catch (error: any) {
         const errormessage = `Issue encountered while parsing device "${value.name}" in the device configuration file devices.json: ${error.message}`;
         this.logger.error(errormessage);
         throw new Error(errormessage);

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -98,6 +98,7 @@ export type Device = {
   readonly wikiUrl?: Maybe<Scalars['String']>;
   readonly deviceType: DeviceType;
   readonly parent?: Maybe<Scalars['String']>;
+  readonly abbreviatedName?: Maybe<Scalars['String']>;
 };
 
 export type Target = {
@@ -459,6 +460,7 @@ export type AvailableFirmwareTargetsQuery = {
       | 'userDefines'
       | 'deviceType'
       | 'parent'
+      | 'abbreviatedName'
     > & {
         readonly targets: ReadonlyArray<
           { readonly __typename?: 'Target' } & Pick<
@@ -838,6 +840,7 @@ export const AvailableFirmwareTargetsDocument = gql`
       userDefines
       deviceType
       parent
+      abbreviatedName
     }
   }
 `;

--- a/src/ui/gql/queries/availableFirmwareTargets.graphql
+++ b/src/ui/gql/queries/availableFirmwareTargets.graphql
@@ -28,5 +28,6 @@ query availableFirmwareTargets(
     userDefines
     deviceType
     parent
+    abbreviatedName
   }
 }

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -554,6 +554,10 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
     setViewState(ViewState.Configuration);
   };
 
+  const getAbbreviatedDeviceName = (item: Device) => {
+    return item.abbreviatedName?.slice(0, 16) ?? item.name?.slice(0, 16);
+  };
+
   const [currentJobType, setCurrentJobType] = useState<BuildJobType>(
     BuildJobType.Build
   );
@@ -619,10 +623,11 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
     }));
 
     if (device?.parent && device?.name) {
+      const deviceName = getAbbreviatedDeviceName(device);
       // add the user define for the device name
       userDefines.push({
         key: UserDefineKey.DEVICE_NAME,
-        value: device?.name.slice(0, 20),
+        value: deviceName,
         enabled: true,
         enumValues: null,
         type: UserDefineKind.Text,
@@ -683,7 +688,7 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
 
         // try to find the device by the deviceName
         deviceMatches = deviceTargets?.filter((item) => {
-          return item.name.toUpperCase() === dnsDeviceName;
+          return getAbbreviatedDeviceName(item).toUpperCase() === dnsDeviceName;
         });
 
         // if no matches found by deviceName, then use the target


### PR DESCRIPTION
Add abbreviated name property to alias devices and use it to populate the DEVICE_NAME user define.

Closes #156