### PR TITLE
Disable wifi device alerts during build

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -15,6 +15,7 @@ import { Config } from './config';
 import { DeviceType, MulticastDnsInformation } from './gql/generated/types';
 import useNetworkDevices from './hooks/useNetworkDevices';
 import WifiDeviceNotification from './components/WifiDeviceNotification';
+import AppStateProvider from './context/AppStateProvider';
 
 export default function App() {
   const {
@@ -46,49 +47,51 @@ export default function App() {
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <ApolloProvider client={client}>
-          <HashRouter>
-            <Routes>
-              <Route
-                path="/"
-                element={<Navigate replace to="/configurator" />}
-              />
-              <Route
-                path="/configurator"
-                element={
-                  <ConfiguratorView
-                    key="configurator"
-                    gitRepository={Config.expressLRSGit}
-                    selectedDevice={device}
-                    networkDevices={networkDevices}
-                    onDeviceChange={onDeviceChange}
-                    deviceType={DeviceType.ExpressLRS}
-                  />
-                }
-              />
-              <Route
-                path="/backpack"
-                element={
-                  <ConfiguratorView
-                    key="backpack"
-                    gitRepository={Config.backpackGit}
-                    selectedDevice={device}
-                    networkDevices={networkDevices}
-                    onDeviceChange={onDeviceChange}
-                    deviceType={DeviceType.Backpack}
-                  />
-                }
-              />
-              <Route path="/settings" element={<SettingsView />} />
-              <Route path="/logs" element={<LogsView />} />
-              <Route path="/serial-monitor" element={<SerialMonitorView />} />
-              <Route path="/support" element={<SupportView />} />
-            </Routes>
-          </HashRouter>
-          <WifiDeviceNotification
-            newNetworkDevices={newNetworkDevices}
-            removeDeviceFromNewList={removeDeviceFromNewList}
-            onDeviceChange={onDeviceChange}
-          />
+          <AppStateProvider>
+            <HashRouter>
+              <Routes>
+                <Route
+                  path="/"
+                  element={<Navigate replace to="/configurator" />}
+                />
+                <Route
+                  path="/configurator"
+                  element={
+                    <ConfiguratorView
+                      key="configurator"
+                      gitRepository={Config.expressLRSGit}
+                      selectedDevice={device}
+                      networkDevices={networkDevices}
+                      onDeviceChange={onDeviceChange}
+                      deviceType={DeviceType.ExpressLRS}
+                    />
+                  }
+                />
+                <Route
+                  path="/backpack"
+                  element={
+                    <ConfiguratorView
+                      key="backpack"
+                      gitRepository={Config.backpackGit}
+                      selectedDevice={device}
+                      networkDevices={networkDevices}
+                      onDeviceChange={onDeviceChange}
+                      deviceType={DeviceType.Backpack}
+                    />
+                  }
+                />
+                <Route path="/settings" element={<SettingsView />} />
+                <Route path="/logs" element={<LogsView />} />
+                <Route path="/serial-monitor" element={<SerialMonitorView />} />
+                <Route path="/support" element={<SupportView />} />
+              </Routes>
+            </HashRouter>
+            <WifiDeviceNotification
+              newNetworkDevices={newNetworkDevices}
+              removeDeviceFromNewList={removeDeviceFromNewList}
+              onDeviceChange={onDeviceChange}
+            />
+          </AppStateProvider>
         </ApolloProvider>
       </ThemeProvider>
     </StyledEngineProvider>

--- a/src/ui/components/Sidebar/index.tsx
+++ b/src/ui/components/Sidebar/index.tsx
@@ -16,6 +16,8 @@ import DvrIcon from '@mui/icons-material/Dvr';
 import ListIcon from '@mui/icons-material/List';
 import { matchPath, useLocation, Link } from 'react-router-dom';
 import BackpackIcon from '@mui/icons-material/Backpack';
+import useAppState from '../../hooks/useAppState';
+import AppStatus from '../../models/enum/AppStatus';
 
 const drawerWidth = 215;
 
@@ -36,11 +38,7 @@ const styles = {
   },
 };
 
-interface SidebarProps {
-  navigationEnabled: boolean;
-}
-
-const Sidebar: FunctionComponent<SidebarProps> = ({ navigationEnabled }) => {
+const Sidebar: FunctionComponent = () => {
   const location = useLocation();
   const configuratorActive =
     matchPath(location.pathname, '/configurator') !== null;
@@ -50,6 +48,9 @@ const Sidebar: FunctionComponent<SidebarProps> = ({ navigationEnabled }) => {
   const serialMonitorActive =
     matchPath(location.pathname, '/serial-monitor') !== null;
   const supportActive = matchPath(location.pathname, '/support') !== null;
+  const { appStatus } = useAppState();
+
+  const navigationEnabled = appStatus !== AppStatus.Busy;
 
   return (
     <Drawer sx={styles.drawer} variant="permanent">

--- a/src/ui/components/WifiDeviceNotification/index.tsx
+++ b/src/ui/components/WifiDeviceNotification/index.tsx
@@ -1,6 +1,8 @@
 import { Alert, Button, Snackbar } from '@mui/material';
 import React, { FunctionComponent } from 'react';
 import { MulticastDnsInformation } from '../../gql/generated/types';
+import useAppState from '../../hooks/useAppState';
+import AppStatus from '../../models/enum/AppStatus';
 
 interface WifiDeviceNotificationProps {
   newNetworkDevices: MulticastDnsInformation[];
@@ -12,36 +14,38 @@ const WifiDeviceNotification: FunctionComponent<WifiDeviceNotificationProps> = (
   props
 ) => {
   const { newNetworkDevices, removeDeviceFromNewList, onDeviceChange } = props;
+  const { appStatus } = useAppState();
 
   return (
     <>
-      {newNetworkDevices.map((dnsDevice) => {
-        const handleClose = () => {
-          removeDeviceFromNewList(dnsDevice.name);
-        };
+      {appStatus === AppStatus.Interactive &&
+        newNetworkDevices.map((dnsDevice) => {
+          const handleClose = () => {
+            removeDeviceFromNewList(dnsDevice.name);
+          };
 
-        return (
-          <Snackbar
-            key={dnsDevice.name}
-            open
-            autoHideDuration={6000}
-            onClose={handleClose}
-          >
-            <Alert onClose={handleClose} severity="info">
-              New Device {dnsDevice.name} ({dnsDevice.ip})
-              <Button
-                size="small"
-                onClick={() => {
-                  onDeviceChange(dnsDevice);
-                  removeDeviceFromNewList(dnsDevice.name);
-                }}
-              >
-                Select
-              </Button>
-            </Alert>
-          </Snackbar>
-        );
-      })}
+          return (
+            <Snackbar
+              key={dnsDevice.name}
+              open
+              autoHideDuration={6000}
+              onClose={handleClose}
+            >
+              <Alert onClose={handleClose} severity="info">
+                New Device {dnsDevice.name} ({dnsDevice.ip})
+                <Button
+                  size="small"
+                  onClick={() => {
+                    onDeviceChange(dnsDevice);
+                    removeDeviceFromNewList(dnsDevice.name);
+                  }}
+                >
+                  Select
+                </Button>
+              </Alert>
+            </Snackbar>
+          );
+        })}
     </>
   );
 };

--- a/src/ui/context/AppStateProvider.tsx
+++ b/src/ui/context/AppStateProvider.tsx
@@ -1,0 +1,25 @@
+import React, { FunctionComponent, useState } from 'react';
+import AppState from '../models/AppState';
+import AppStatus from '../models/enum/AppStatus';
+
+export const AppStateContext = React.createContext<{
+  appState: AppState;
+  setAppState: (appState: AppState) => void;
+}>({
+  appState: { appStatus: AppStatus.Interactive },
+  setAppState: () => {},
+});
+
+const AppStateProvider: FunctionComponent = ({ children }) => {
+  const [appState, setAppState] = useState<AppState>({
+    appStatus: AppStatus.Interactive,
+  });
+
+  return (
+    <AppStateContext.Provider value={{ appState, setAppState }}>
+      {children}
+    </AppStateContext.Provider>
+  );
+};
+
+export default AppStateProvider;

--- a/src/ui/hooks/useAppState.tsx
+++ b/src/ui/hooks/useAppState.tsx
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import { AppStateContext } from '../context/AppStateProvider';
+import AppStatus from '../models/enum/AppStatus';
+
+export default function useAppState() {
+  const context = useContext(AppStateContext);
+  if (context === undefined)
+    throw new Error(`No provider for AppStateContext given`);
+
+  const { appState, setAppState } = context;
+
+  const setAppStatus = (mode: AppStatus) => {
+    setAppState({ ...appState, appStatus: mode });
+  };
+
+  return { ...appState, setAppStatus };
+}

--- a/src/ui/layouts/MainLayout/index.tsx
+++ b/src/ui/layouts/MainLayout/index.tsx
@@ -1,0 +1,34 @@
+import React, { FunctionComponent } from 'react';
+import { Box, Container } from '@mui/material';
+import Header from '../../components/Header';
+import Sidebar from '../../components/Sidebar';
+
+const styles = {
+  root: {
+    display: 'flex',
+  },
+  main: {
+    marginY: 4,
+  },
+  content: {
+    flexGrow: 1,
+    '& .MuiCard-root': {
+      marginBottom: 4,
+    },
+  },
+};
+
+const MainLayout: FunctionComponent = (props) => {
+  const { children } = props;
+  return (
+    <Box component="main" sx={styles.root}>
+      <Sidebar />
+      <Box sx={styles.content}>
+        <Header />
+        <Container sx={styles.main}>{children}</Container>
+      </Box>
+    </Box>
+  );
+};
+
+export default MainLayout;

--- a/src/ui/models/AppState.tsx
+++ b/src/ui/models/AppState.tsx
@@ -1,0 +1,5 @@
+import AppStatus from './enum/AppStatus';
+
+export default interface AppState {
+  appStatus: AppStatus;
+}

--- a/src/ui/models/enum/AppStatus.tsx
+++ b/src/ui/models/enum/AppStatus.tsx
@@ -1,0 +1,6 @@
+enum AppStatus {
+  Interactive = 'Interactive',
+  Busy = 'https://xkcd.com/1084/',
+}
+
+export default AppStatus;

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -13,7 +13,6 @@ import {
   Button,
   Card,
   CardContent,
-  Container,
   Dialog,
   DialogActions,
   DialogContent,
@@ -25,13 +24,11 @@ import {
 import SettingsIcon from '@mui/icons-material/Settings';
 import { ipcRenderer } from 'electron';
 import { NetworkWifi } from '@mui/icons-material';
-import Header from '../../components/Header';
 import FirmwareVersionForm from '../../components/FirmwareVersionForm';
 import DeviceTargetForm from '../../components/DeviceTargetForm';
 import DeviceOptionsForm, {
   DeviceOptionsFormData,
 } from '../../components/DeviceOptionsForm';
-import Sidebar from '../../components/Sidebar';
 import ShowAlerts from '../../components/ShowAlerts';
 import CardTitle from '../../components/CardTitle';
 import EventsBatcher from '../../library/EventsBatcher';
@@ -78,20 +75,9 @@ import GitRepository from '../../models/GitRepository';
 import ShowTimeoutAlerts from '../../components/ShowTimeoutAlerts';
 import useAppState from '../../hooks/useAppState';
 import AppStatus from '../../models/enum/AppStatus';
+import MainLayout from '../../layouts/MainLayout';
 
 const styles = {
-  root: {
-    display: 'flex',
-  },
-  main: {
-    marginY: 4,
-  },
-  content: {
-    flexGrow: 1,
-    '& .MuiCard-root': {
-      marginBottom: 4,
-    },
-  },
   button: {
     marginRight: 2,
   },
@@ -775,306 +761,289 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
   }, []);
 
   return (
-    <Box component="main" sx={styles.root}>
-      <Sidebar />
-      <Box sx={styles.content}>
-        <Header />
-        <Container sx={styles.main}>
-          {viewState === ViewState.Configuration && (
-            <>
-              <Card>
-                <CardTitle icon={<SettingsIcon />} title="Firmware version" />
-                <Divider />
-                <CardContent>
-                  <FirmwareVersionForm
-                    onChange={onFirmwareVersionData}
-                    data={firmwareVersionData}
-                    gitRepository={gitRepository}
-                  />
-                  <ShowAlerts
-                    severity="error"
-                    messages={firmwareVersionErrors}
-                  />
-                </CardContent>
-                <Divider />
+    <MainLayout>
+      {viewState === ViewState.Configuration && (
+        <>
+          <Card>
+            <CardTitle icon={<SettingsIcon />} title="Firmware version" />
+            <Divider />
+            <CardContent>
+              <FirmwareVersionForm
+                onChange={onFirmwareVersionData}
+                data={firmwareVersionData}
+                gitRepository={gitRepository}
+              />
+              <ShowAlerts severity="error" messages={firmwareVersionErrors} />
+            </CardContent>
+            <Divider />
 
-                <CardTitle icon={<SettingsIcon />} title="Target" />
-                <Divider />
-                <CardContent>
-                  {!loadingTargets && !targetsResponseError && (
-                    <DeviceTargetForm
-                      currentTarget={deviceTarget}
-                      onChange={onDeviceTarget}
-                      firmwareVersionData={firmwareVersionData}
-                      deviceOptions={deviceTargets}
-                    />
-                  )}
-                  <Loader loading={loadingTargets} />
-                  {luaDownloadButton()}
-                  {hasLuaScript && (
-                    <ShowAlerts
-                      severity="error"
-                      messages={luaScriptResponseError}
-                    />
-                  )}
-                  <ShowAlerts
-                    severity="error"
-                    messages={targetsResponseError}
-                  />
-                  <ShowAlerts severity="error" messages={deviceTargetErrors} />
-                </CardContent>
-                <Divider />
-
-                <CardTitle
-                  icon={<SettingsIcon />}
-                  title={
-                    <div ref={deviceOptionsRef}>
-                      Device options{' '}
-                      {deviceOptionsFormData.userDefinesMode ===
-                        UserDefinesMode.UserInterface &&
-                        deviceTarget !== null &&
-                        !loadingOptions && (
-                          <Tooltip
-                            placement="top"
-                            arrow
-                            title={
-                              <div>
-                                Reset device options to the recommended defaults
-                                on this device target. Except for your custom
-                                binding phrase.
-                              </div>
-                            }
-                          >
-                            <Button onClick={onResetToDefaults} size="small">
-                              Reset
-                            </Button>
-                          </Tooltip>
-                        )}
-                    </div>
-                  }
+            <CardTitle icon={<SettingsIcon />} title="Target" />
+            <Divider />
+            <CardContent>
+              {!loadingTargets && !targetsResponseError && (
+                <DeviceTargetForm
+                  currentTarget={deviceTarget}
+                  onChange={onDeviceTarget}
+                  firmwareVersionData={firmwareVersionData}
+                  deviceOptions={deviceTargets}
                 />
-                <Divider />
-                <CardContent>
-                  {!loadingOptions && (
-                    <DeviceOptionsForm
-                      target={deviceTarget?.name ?? null}
-                      deviceOptions={deviceOptionsFormData}
-                      firmwareVersionData={firmwareVersionData}
-                      onChange={onUserDefines}
-                    />
-                  )}
-                  <ShowAlerts
-                    severity="error"
-                    messages={deviceOptionsResponseError}
-                  />
-                  <ShowAlerts
-                    severity="error"
-                    messages={deviceOptionsValidationErrors}
-                  />
-                  <Loader loading={loadingOptions} />
-                </CardContent>
-                <Divider />
-
-                <CardTitle icon={<SettingsIcon />} title="Actions" />
-                <Divider />
-                <CardContent>
-                  <UserDefinesAdvisor
-                    deviceOptionsFormData={deviceOptionsFormData}
-                  />
-
-                  <div>
-                    {serialPortRequired && (
-                      <SerialDeviceSelect
-                        serialDevice={serialDevice}
-                        onChange={onSerialDevice}
-                      />
-                    )}
-                    {wifiDeviceRequired && (
-                      <WifiDeviceSelect
-                        wifiDevice={wifiDevice}
-                        wifiDevices={Array.from(networkDevices.values()).filter(
-                          (item) => {
-                            return deviceTarget?.name
-                              ?.toUpperCase()
-                              .startsWith(item.target.toUpperCase());
-                          }
-                        )}
-                        onChange={onWifiDevice}
-                      />
-                    )}
-                    <Button
-                      sx={styles.button}
-                      size="large"
-                      variant="contained"
-                      onClick={onBuild}
-                    >
-                      Build
-                    </Button>
-                    {deviceTarget?.flashingMethod !== FlashingMethod.Radio && (
-                      <Button
-                        sx={styles.button}
-                        size="large"
-                        variant="contained"
-                        onClick={onBuildAndFlash}
-                      >
-                        Build & Flash
-                      </Button>
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
-              <Card>
-                {networkDevices.size > 0 && (
-                  <Box>
-                    <Divider />
-                    <CardTitle icon={<NetworkWifi />} title="Network Devices" />
-                    <Divider />
-                    <CardContent>
-                      <div>
-                        <WifiDeviceList
-                          wifiDevices={Array.from(networkDevices.values())}
-                          onChange={(dnsDevice: MulticastDnsInformation) => {
-                            onDeviceChange(dnsDevice);
-                            handleSelectedDeviceChange(dnsDevice.name);
-                          }}
-                        />
-                      </div>
-                    </CardContent>
-                  </Box>
-                )}
-              </Card>
-              <Dialog
-                open={deviceSelectErrorDialogOpen}
-                onClose={handleDeviceSelectErrorDialogClose}
-                aria-labelledby="alert-dialog-title"
-                aria-describedby="alert-dialog-description"
-              >
-                <DialogTitle id="alert-dialog-title">
-                  Device Select Error
-                </DialogTitle>
-                <DialogContent>
-                  <DialogContentText id="alert-dialog-description">
-                    The target device could not be automatically selected, it
-                    must be done manually.
-                  </DialogContentText>
-                </DialogContent>
-                <DialogActions>
-                  <Button onClick={handleDeviceSelectErrorDialogClose}>
-                    Close
-                  </Button>
-                </DialogActions>
-              </Dialog>
-            </>
-          )}
-
-          {viewState === ViewState.Compiling && (
-            <Card>
-              <CardTitle icon={<SettingsIcon />} title="Build" />
-              <Divider />
-              <CardContent>
-                <BuildProgressBar
-                  inProgress={buildInProgress}
-                  jobType={currentJobType}
-                  progressNotification={lastProgressNotification}
-                />
-                <BuildNotificationsList notifications={progressNotifications} />
-
+              )}
+              <Loader loading={loadingTargets} />
+              {luaDownloadButton()}
+              {hasLuaScript && (
                 <ShowAlerts
                   severity="error"
-                  messages={buildFlashErrorResponse}
+                  messages={luaScriptResponseError}
                 />
-              </CardContent>
-
-              {logs.length > 0 && (
-                <>
-                  <CardTitle icon={<SettingsIcon />} title="Logs" />
-                  <Divider />
-                  <CardContent>
-                    <Box sx={styles.longBuildDurationWarning}>
-                      <ShowTimeoutAlerts
-                        severity="warning"
-                        messages="Sometimes builds take at least a few minutes. It is normal, especially for the first time builds."
-                        active={buildInProgress}
-                        timeout={14 * 1000}
-                      />
-                    </Box>
-                    <Logs data={logs} />
-                  </CardContent>
-                  <Divider />
-                </>
               )}
-              {response !== undefined && (
-                <>
-                  <CardTitle icon={<SettingsIcon />} title="Result" />
-                  <Divider />
-                  <CardContent>
-                    <Box sx={styles.buildNotification}>
-                      <BuildResponse response={response?.buildFlashFirmware} />
-                    </Box>
-                    {response?.buildFlashFirmware?.success &&
-                      currentJobType === BuildJobType.Build && (
-                        <>
-                          <Alert sx={styles.buildNotification} severity="info">
-                            <AlertTitle>Build notice</AlertTitle>
-                            {deviceTarget?.flashingMethod !==
-                            FlashingMethod.Radio
-                              ? 'Firmware binary file was opened in the file explorer'
-                              : "Firmware binary file was opened in the file explorer, copy the firmware file to your radios's SD card and flash it to the transmitter using EdgeTX/OpenTX"}
-                          </Alert>
-                        </>
-                      )}
-                    {response?.buildFlashFirmware?.success && hasLuaScript && (
-                      <>
-                        <Alert sx={styles.buildNotification} severity="info">
-                          <AlertTitle>Update Lua Script</AlertTitle>
-                          Make sure to update the Lua script on your radio
-                        </Alert>
-                      </>
-                    )}
-                  </CardContent>
-                  <Divider />
-                </>
-              )}
-              {!buildInProgress && (
-                <>
-                  <CardTitle icon={<SettingsIcon />} title="Actions" />
-                  <Divider />
-                  <CardContent>
-                    <Button
-                      sx={styles.button}
-                      color="primary"
-                      size="large"
-                      variant="contained"
-                      onClick={onBack}
-                    >
-                      Back
-                    </Button>
+              <ShowAlerts severity="error" messages={targetsResponseError} />
+              <ShowAlerts severity="error" messages={deviceTargetErrors} />
+            </CardContent>
+            <Divider />
 
-                    {!response?.buildFlashFirmware.success && (
-                      <Button
-                        sx={styles.button}
-                        size="large"
-                        variant="contained"
-                        onClick={
-                          currentJobType === BuildJobType.Build
-                            ? onBuild
-                            : onBuildAndFlash
+            <CardTitle
+              icon={<SettingsIcon />}
+              title={
+                <div ref={deviceOptionsRef}>
+                  Device options{' '}
+                  {deviceOptionsFormData.userDefinesMode ===
+                    UserDefinesMode.UserInterface &&
+                    deviceTarget !== null &&
+                    !loadingOptions && (
+                      <Tooltip
+                        placement="top"
+                        arrow
+                        title={
+                          <div>
+                            Reset device options to the recommended defaults on
+                            this device target. Except for your custom binding
+                            phrase.
+                          </div>
                         }
                       >
-                        Retry
-                      </Button>
+                        <Button onClick={onResetToDefaults} size="small">
+                          Reset
+                        </Button>
+                      </Tooltip>
                     )}
-
-                    {response?.buildFlashFirmware.success &&
-                      luaDownloadButton()}
-                  </CardContent>
-                </>
+                </div>
+              }
+            />
+            <Divider />
+            <CardContent>
+              {!loadingOptions && (
+                <DeviceOptionsForm
+                  target={deviceTarget?.name ?? null}
+                  deviceOptions={deviceOptionsFormData}
+                  firmwareVersionData={firmwareVersionData}
+                  onChange={onUserDefines}
+                />
               )}
-            </Card>
+              <ShowAlerts
+                severity="error"
+                messages={deviceOptionsResponseError}
+              />
+              <ShowAlerts
+                severity="error"
+                messages={deviceOptionsValidationErrors}
+              />
+              <Loader loading={loadingOptions} />
+            </CardContent>
+            <Divider />
+
+            <CardTitle icon={<SettingsIcon />} title="Actions" />
+            <Divider />
+            <CardContent>
+              <UserDefinesAdvisor
+                deviceOptionsFormData={deviceOptionsFormData}
+              />
+
+              <div>
+                {serialPortRequired && (
+                  <SerialDeviceSelect
+                    serialDevice={serialDevice}
+                    onChange={onSerialDevice}
+                  />
+                )}
+                {wifiDeviceRequired && (
+                  <WifiDeviceSelect
+                    wifiDevice={wifiDevice}
+                    wifiDevices={Array.from(networkDevices.values()).filter(
+                      (item) => {
+                        return deviceTarget?.name
+                          ?.toUpperCase()
+                          .startsWith(item.target.toUpperCase());
+                      }
+                    )}
+                    onChange={onWifiDevice}
+                  />
+                )}
+                <Button
+                  sx={styles.button}
+                  size="large"
+                  variant="contained"
+                  onClick={onBuild}
+                >
+                  Build
+                </Button>
+                {deviceTarget?.flashingMethod !== FlashingMethod.Radio && (
+                  <Button
+                    sx={styles.button}
+                    size="large"
+                    variant="contained"
+                    onClick={onBuildAndFlash}
+                  >
+                    Build & Flash
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            {networkDevices.size > 0 && (
+              <Box>
+                <Divider />
+                <CardTitle icon={<NetworkWifi />} title="Network Devices" />
+                <Divider />
+                <CardContent>
+                  <div>
+                    <WifiDeviceList
+                      wifiDevices={Array.from(networkDevices.values())}
+                      onChange={(dnsDevice: MulticastDnsInformation) => {
+                        onDeviceChange(dnsDevice);
+                        handleSelectedDeviceChange(dnsDevice.name);
+                      }}
+                    />
+                  </div>
+                </CardContent>
+              </Box>
+            )}
+          </Card>
+          <Dialog
+            open={deviceSelectErrorDialogOpen}
+            onClose={handleDeviceSelectErrorDialogClose}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+          >
+            <DialogTitle id="alert-dialog-title">
+              Device Select Error
+            </DialogTitle>
+            <DialogContent>
+              <DialogContentText id="alert-dialog-description">
+                The target device could not be automatically selected, it must
+                be done manually.
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleDeviceSelectErrorDialogClose}>
+                Close
+              </Button>
+            </DialogActions>
+          </Dialog>
+        </>
+      )}
+
+      {viewState === ViewState.Compiling && (
+        <Card>
+          <CardTitle icon={<SettingsIcon />} title="Build" />
+          <Divider />
+          <CardContent>
+            <BuildProgressBar
+              inProgress={buildInProgress}
+              jobType={currentJobType}
+              progressNotification={lastProgressNotification}
+            />
+            <BuildNotificationsList notifications={progressNotifications} />
+
+            <ShowAlerts severity="error" messages={buildFlashErrorResponse} />
+          </CardContent>
+
+          {logs.length > 0 && (
+            <>
+              <CardTitle icon={<SettingsIcon />} title="Logs" />
+              <Divider />
+              <CardContent>
+                <Box sx={styles.longBuildDurationWarning}>
+                  <ShowTimeoutAlerts
+                    severity="warning"
+                    messages="Sometimes builds take at least a few minutes. It is normal, especially for the first time builds."
+                    active={buildInProgress}
+                    timeout={14 * 1000}
+                  />
+                </Box>
+                <Logs data={logs} />
+              </CardContent>
+              <Divider />
+            </>
           )}
-        </Container>
-      </Box>
-    </Box>
+          {response !== undefined && (
+            <>
+              <CardTitle icon={<SettingsIcon />} title="Result" />
+              <Divider />
+              <CardContent>
+                <Box sx={styles.buildNotification}>
+                  <BuildResponse response={response?.buildFlashFirmware} />
+                </Box>
+                {response?.buildFlashFirmware?.success &&
+                  currentJobType === BuildJobType.Build && (
+                    <>
+                      <Alert sx={styles.buildNotification} severity="info">
+                        <AlertTitle>Build notice</AlertTitle>
+                        {deviceTarget?.flashingMethod !== FlashingMethod.Radio
+                          ? 'Firmware binary file was opened in the file explorer'
+                          : "Firmware binary file was opened in the file explorer, copy the firmware file to your radios's SD card and flash it to the transmitter using EdgeTX/OpenTX"}
+                      </Alert>
+                    </>
+                  )}
+                {response?.buildFlashFirmware?.success && hasLuaScript && (
+                  <>
+                    <Alert sx={styles.buildNotification} severity="info">
+                      <AlertTitle>Update Lua Script</AlertTitle>
+                      Make sure to update the Lua script on your radio
+                    </Alert>
+                  </>
+                )}
+              </CardContent>
+              <Divider />
+            </>
+          )}
+          {!buildInProgress && (
+            <>
+              <CardTitle icon={<SettingsIcon />} title="Actions" />
+              <Divider />
+              <CardContent>
+                <Button
+                  sx={styles.button}
+                  color="primary"
+                  size="large"
+                  variant="contained"
+                  onClick={onBack}
+                >
+                  Back
+                </Button>
+
+                {!response?.buildFlashFirmware.success && (
+                  <Button
+                    sx={styles.button}
+                    size="large"
+                    variant="contained"
+                    onClick={
+                      currentJobType === BuildJobType.Build
+                        ? onBuild
+                        : onBuildAndFlash
+                    }
+                  >
+                    Retry
+                  </Button>
+                )}
+
+                {response?.buildFlashFirmware.success && luaDownloadButton()}
+              </CardContent>
+            </>
+          )}
+        </Card>
+      )}
+    </MainLayout>
   );
 };
 

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -776,7 +776,7 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
 
   return (
     <Box component="main" sx={styles.root}>
-      <Sidebar navigationEnabled={!buildInProgress} />
+      <Sidebar />
       <Box sx={styles.content}>
         <Header />
         <Container sx={styles.main}>

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -76,6 +76,8 @@ import WifiDeviceSelect from '../../components/WifiDeviceSelect';
 import WifiDeviceList from '../../components/WifiDeviceList';
 import GitRepository from '../../models/GitRepository';
 import ShowTimeoutAlerts from '../../components/ShowTimeoutAlerts';
+import useAppState from '../../hooks/useAppState';
+import AppStatus from '../../models/enum/AppStatus';
 
 const styles = {
   root: {
@@ -164,6 +166,8 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
   const [viewState, setViewState] = useState<ViewState>(
     ViewState.Configuration
   );
+
+  const { setAppStatus } = useAppState();
 
   const [progressNotifications, setProgressNotifications] = useState<
     BuildProgressNotification[]
@@ -548,6 +552,7 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
   const onBack = () => {
     reset();
     setViewState(ViewState.Configuration);
+    setAppStatus(AppStatus.Interactive);
   };
 
   const getAbbreviatedDeviceName = (item: Device) => {
@@ -652,6 +657,7 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
       },
     });
     setViewState(ViewState.Compiling);
+    setAppStatus(AppStatus.Busy);
   };
 
   useEffect(() => {

--- a/src/ui/views/LogsView/index.tsx
+++ b/src/ui/views/LogsView/index.tsx
@@ -1,58 +1,32 @@
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  Divider,
-} from '@mui/material';
+import { Button, Card, CardContent, Divider } from '@mui/material';
 import React, { FunctionComponent } from 'react';
 import ListIcon from '@mui/icons-material/List';
 import { ipcRenderer } from 'electron';
-import Sidebar from '../../components/Sidebar';
-import Header from '../../components/Header';
 import CardTitle from '../../components/CardTitle';
 import { IpcRequest } from '../../../ipc';
-
-const styles = {
-  root: {
-    display: 'flex',
-  },
-  main: {
-    marginY: 4,
-  },
-  content: {
-    flexGrow: 1,
-  },
-};
+import MainLayout from '../../layouts/MainLayout';
 
 const LogsView: FunctionComponent = () => {
   const onLogs = () => {
     ipcRenderer.send(IpcRequest.OpenLogsFolder);
   };
   return (
-    <Box component="main" sx={styles.root}>
-      <Sidebar />
-      <Box sx={styles.content}>
-        <Header />
-        <Container sx={styles.main}>
-          <Card>
-            <CardTitle icon={<ListIcon />} title="Logs" />
-            <Divider />
-            <CardContent>
-              <Button
-                color="primary"
-                size="large"
-                variant="contained"
-                onClick={onLogs}
-              >
-                Open logs folder
-              </Button>
-            </CardContent>
-          </Card>
-        </Container>
-      </Box>
-    </Box>
+    <MainLayout>
+      <Card>
+        <CardTitle icon={<ListIcon />} title="Logs" />
+        <Divider />
+        <CardContent>
+          <Button
+            color="primary"
+            size="large"
+            variant="contained"
+            onClick={onLogs}
+          >
+            Open logs folder
+          </Button>
+        </CardContent>
+      </Card>
+    </MainLayout>
   );
 };
 

--- a/src/ui/views/LogsView/index.tsx
+++ b/src/ui/views/LogsView/index.tsx
@@ -32,7 +32,7 @@ const LogsView: FunctionComponent = () => {
   };
   return (
     <Box component="main" sx={styles.root}>
-      <Sidebar navigationEnabled />
+      <Sidebar />
       <Box sx={styles.content}>
         <Header />
         <Container sx={styles.main}>

--- a/src/ui/views/SerialMonitorView/index.tsx
+++ b/src/ui/views/SerialMonitorView/index.tsx
@@ -1,15 +1,6 @@
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  Divider,
-} from '@mui/material';
+import { Button, Card, CardContent, Divider } from '@mui/material';
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
 import DvrIcon from '@mui/icons-material/Dvr';
-import Sidebar from '../../components/Sidebar';
-import Header from '../../components/Header';
 import CardTitle from '../../components/CardTitle';
 import SerialConnectionForm from '../../components/SerialConnectionForm';
 import EventsBatcher from '../../library/EventsBatcher';
@@ -23,17 +14,9 @@ import {
 import Loader from '../../components/Loader';
 import ShowAlerts from '../../components/ShowAlerts';
 import Logs from '../../components/Logs';
+import MainLayout from '../../layouts/MainLayout';
 
 const styles = {
-  root: {
-    display: 'flex',
-  },
-  main: {
-    marginY: 4,
-  },
-  content: {
-    flexGrow: 1,
-  },
   disconnectButton: {
     marginBottom: 4,
   },
@@ -127,53 +110,47 @@ const SerialMonitorView: FunctionComponent = () => {
       .catch(() => {});
   };
   return (
-    <Box component="main" sx={styles.root}>
-      <Sidebar />
-      <Box sx={styles.content}>
-        <Header />
-        <Container sx={styles.main}>
-          <Card>
-            <CardTitle icon={<DvrIcon />} title="Serial Monitor" />
-            <Divider />
-            <CardContent>
-              {viewState === ViewState.ConnectionConfig && (
-                <>
-                  <SerialConnectionForm
-                    serialDevice={serialDevice}
-                    baudRate={baudRate}
-                    onConnect={onConnect}
-                  />
-                  <Loader loading={connectInProgress} />
-                  {response && !response.connectToSerialDevice.success && (
-                    <ShowAlerts
-                      severity="error"
-                      messages={response.connectToSerialDevice.message}
-                    />
-                  )}
-                  <ShowAlerts severity="error" messages={connectError} />
-                </>
+    <MainLayout>
+      <Card>
+        <CardTitle icon={<DvrIcon />} title="Serial Monitor" />
+        <Divider />
+        <CardContent>
+          {viewState === ViewState.ConnectionConfig && (
+            <>
+              <SerialConnectionForm
+                serialDevice={serialDevice}
+                baudRate={baudRate}
+                onConnect={onConnect}
+              />
+              <Loader loading={connectInProgress} />
+              {response && !response.connectToSerialDevice.success && (
+                <ShowAlerts
+                  severity="error"
+                  messages={response.connectToSerialDevice.message}
+                />
               )}
-              <ShowAlerts severity="error" messages={disconnectError} />
-              {viewState === ViewState.LogsStream && (
-                <>
-                  <Button
-                    onClick={onDisconnect}
-                    color="secondary"
-                    size="large"
-                    variant="contained"
-                    sx={styles.disconnectButton}
-                  >
-                    Disconnect
-                  </Button>
-                  <Loader loading={disconnectInProgress} />
-                  <Logs data={logs} />
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </Container>
-      </Box>
-    </Box>
+              <ShowAlerts severity="error" messages={connectError} />
+            </>
+          )}
+          <ShowAlerts severity="error" messages={disconnectError} />
+          {viewState === ViewState.LogsStream && (
+            <>
+              <Button
+                onClick={onDisconnect}
+                color="secondary"
+                size="large"
+                variant="contained"
+                sx={styles.disconnectButton}
+              >
+                Disconnect
+              </Button>
+              <Loader loading={disconnectInProgress} />
+              <Logs data={logs} />
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </MainLayout>
   );
 };
 

--- a/src/ui/views/SerialMonitorView/index.tsx
+++ b/src/ui/views/SerialMonitorView/index.tsx
@@ -128,7 +128,7 @@ const SerialMonitorView: FunctionComponent = () => {
   };
   return (
     <Box component="main" sx={styles.root}>
-      <Sidebar navigationEnabled />
+      <Sidebar />
       <Box sx={styles.content}>
         <Header />
         <Container sx={styles.main}>

--- a/src/ui/views/SettingsView/index.tsx
+++ b/src/ui/views/SettingsView/index.tsx
@@ -1,50 +1,24 @@
-import {
-  Box,
-  Card,
-  CardContent,
-  Container,
-  Divider,
-  Typography,
-} from '@mui/material';
+import { Card, CardContent, Divider, Typography } from '@mui/material';
 import React, { FunctionComponent } from 'react';
 import SettingsIcon from '@mui/icons-material/Settings';
-import Sidebar from '../../components/Sidebar';
-import Header from '../../components/Header';
 import CardTitle from '../../components/CardTitle';
-
-const styles = {
-  root: {
-    display: 'flex',
-  },
-  main: {
-    marginY: 4,
-  },
-  content: {
-    flexGrow: 1,
-  },
-};
+import MainLayout from '../../layouts/MainLayout';
 
 const SettingsView: FunctionComponent = () => {
   return (
-    <Box component="main" sx={styles.root}>
-      <Sidebar />
-      <Box sx={styles.content}>
-        <Header />
-        <Container sx={styles.main}>
-          <Card>
-            <CardTitle icon={<SettingsIcon />} title="Settings" />
-            <Divider />
-            <CardContent>
-              <Typography variant="h6">Todo:</Typography>
-              <ul>
-                <li>Display configurator version</li>
-                <li>Language selector</li>
-              </ul>
-            </CardContent>
-          </Card>
-        </Container>
-      </Box>
-    </Box>
+    <MainLayout>
+      <Card>
+        <CardTitle icon={<SettingsIcon />} title="Settings" />
+        <Divider />
+        <CardContent>
+          <Typography variant="h6">Todo:</Typography>
+          <ul>
+            <li>Display configurator version</li>
+            <li>Language selector</li>
+          </ul>
+        </CardContent>
+      </Card>
+    </MainLayout>
   );
 };
 

--- a/src/ui/views/SettingsView/index.tsx
+++ b/src/ui/views/SettingsView/index.tsx
@@ -27,7 +27,7 @@ const styles = {
 const SettingsView: FunctionComponent = () => {
   return (
     <Box component="main" sx={styles.root}>
-      <Sidebar navigationEnabled />
+      <Sidebar />
       <Box sx={styles.content}>
         <Header />
         <Container sx={styles.main}>

--- a/src/ui/views/SupportView/index.tsx
+++ b/src/ui/views/SupportView/index.tsx
@@ -39,7 +39,7 @@ const styles = {
 const SupportView: FunctionComponent = () => {
   return (
     <Box component="main" sx={styles.root}>
-      <Sidebar navigationEnabled />
+      <Sidebar />
       <Box sx={styles.content}>
         <Header />
         <Container sx={styles.main}>

--- a/src/ui/views/SupportView/index.tsx
+++ b/src/ui/views/SupportView/index.tsx
@@ -1,25 +1,13 @@
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Container,
-  Divider,
-} from '@mui/material';
+import { Button, Card, CardContent, Divider } from '@mui/material';
 import React, { FunctionComponent } from 'react';
 import SettingsIcon from '@mui/icons-material/Settings';
-import Sidebar from '../../components/Sidebar';
-import Header from '../../components/Header';
 import CardTitle from '../../components/CardTitle';
 import ClearPlatformioDependencies from './Troubleshooting/ClearPlatformioDependencies';
 import ClearFirmwareFiles from './Troubleshooting/ClearFirmwareFiles';
+import MainLayout from '../../layouts/MainLayout';
 
 const styles = {
-  root: {
-    display: 'flex',
-  },
-  main: {
-    marginY: 4,
+  listContainer: {
     '& .linksList': {
       paddingLeft: 0,
       marginBottom: 0,
@@ -31,79 +19,70 @@ const styles = {
       },
     },
   },
-  content: {
-    flexGrow: 1,
-  },
 };
 
 const SupportView: FunctionComponent = () => {
   return (
-    <Box component="main" sx={styles.root}>
-      <Sidebar />
-      <Box sx={styles.content}>
-        <Header />
-        <Container sx={styles.main}>
-          <Card>
-            <CardTitle icon={<SettingsIcon />} title="Support" />
-            <Divider />
-            <CardContent>
-              <p>Need help? Confused? Join the Community!</p>
-              <ul className="linksList">
-                <li>
-                  <Button
-                    target="_blank"
-                    variant="contained"
-                    rel="noreferrer noreferrer"
-                    href="https://www.expresslrs.org/"
-                  >
-                    ExpressLRS Documentation
-                  </Button>
-                </li>
-                <li>
-                  <Button
-                    target="_blank"
-                    variant="contained"
-                    rel="noreferrer noreferrer"
-                    href="https://discord.gg/dS6ReFY"
-                  >
-                    Discord Chat
-                  </Button>
-                </li>
-                <li>
-                  <Button
-                    target="_blank"
-                    variant="contained"
-                    rel="noreferrer noreferrer"
-                    href="https://www.facebook.com/groups/636441730280366"
-                  >
-                    Facebook Group
-                  </Button>
-                </li>
-              </ul>
-            </CardContent>
-            <Divider />
-            <CardTitle icon={<SettingsIcon />} title="Troubleshooting" />
-            <Divider />
-            <CardContent>
-              <ClearPlatformioDependencies />
-              <ClearFirmwareFiles />
-            </CardContent>
-            <Divider />
-            <CardTitle icon={<SettingsIcon />} title="Legal disclaimer" />
-            <Divider />
-            <CardContent>
-              <p>
-                The use and operation of this type of device may require a
-                license, and some countries may forbid its use. It is entirely
-                up to the end user to ensure compliance with local regulations.
-                This is experimental software / hardware and there is no
-                guarantee of stability or reliability. USE AT YOUR OWN RISK.
-              </p>
-            </CardContent>
-          </Card>
-        </Container>
-      </Box>
-    </Box>
+    <MainLayout>
+      <Card>
+        <CardTitle icon={<SettingsIcon />} title="Support" />
+        <Divider />
+        <CardContent sx={styles.listContainer}>
+          <p>Need help? Confused? Join the Community!</p>
+          <ul className="linksList">
+            <li>
+              <Button
+                target="_blank"
+                variant="contained"
+                rel="noreferrer noreferrer"
+                href="https://www.expresslrs.org/"
+              >
+                ExpressLRS Documentation
+              </Button>
+            </li>
+            <li>
+              <Button
+                target="_blank"
+                variant="contained"
+                rel="noreferrer noreferrer"
+                href="https://discord.gg/dS6ReFY"
+              >
+                Discord Chat
+              </Button>
+            </li>
+            <li>
+              <Button
+                target="_blank"
+                variant="contained"
+                rel="noreferrer noreferrer"
+                href="https://www.facebook.com/groups/636441730280366"
+              >
+                Facebook Group
+              </Button>
+            </li>
+          </ul>
+        </CardContent>
+        <Divider />
+        <CardTitle icon={<SettingsIcon />} title="Troubleshooting" />
+        <Divider />
+        <CardContent>
+          <ClearPlatformioDependencies />
+          <ClearFirmwareFiles />
+        </CardContent>
+        <Divider />
+        <CardTitle icon={<SettingsIcon />} title="Legal disclaimer" />
+        <Divider />
+        <CardContent>
+          <p>
+            The use and operation of this type of device may require a license,
+            and some countries may forbid its use. It is entirely up to the end
+            user to ensure compliance with local regulations. This is
+            experimental software / hardware and there is no guarantee of
+            stability or reliability. USE AT YOUR OWN RISK.
+          </p>
+        </CardContent>
+      </Card>
+    </MainLayout>
   );
 };
 


### PR DESCRIPTION
- Add context to store application state, specifically current application status(whether it is busy or not)
- Disable WIFI device alerts during build/flash - Closes #196
- Use application status to determine whether navigation should be enabled in the side bar
- Refactor views to extract the header and sidebar into a common layout