### PR TITLE
Fixed tx/rx wiki URL path

### DIFF
--- a/devices/betafpv-2400.json
+++ b/devices/betafpv-2400.json
@@ -1,152 +1,145 @@
-[
-  {
-    "category": "BETAFPV 2.4 GHz",
-    "name": "BETAFPV 2400 TX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "BETAFPV_2400_TX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "BETAFPV_2400_TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB",
-      "UNLOCK_HIGHER_POWER"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-betafpv2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": [
-      {
-        "category": "HiYOUNGER 2.4 GHz",
-        "name": "HiYOUNGER TX2G4 2400 TX",
-        "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER TX2G4"
-      }
-    ]
-  },
-  {
-    "category": "BETAFPV 2.4 GHz",
-    "name": "BETAFPV 2400 TX Micro",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "BETAFPV_2400_TX_MICRO_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "BETAFPV_2400_TX_MICRO_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB",
-      "UNLOCK_HIGHER_POWER"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-betafpv2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "BETAFPV 2.4 GHz",
-    "name": "BETAFPV 2400 TX Micro 1000mW",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "BETAFPV_2400_TX_MICRO_1000mw_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "BETAFPV_2400_TX_MICRO_1000mw_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "FEATURE_OPENTX_SYNC",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "UNLOCK_HIGHER_POWER"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-betafpv2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "BETAFPV 2.4 GHz",
-    "name": "BETAFPV 2400 RX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "BETAFPV_2400_RX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "BETAFPV_2400_RX_via_WIFI"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "BETAFPV_2400_RX_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "USE_DIVERSITY",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "RCVR_UART_BAUD",
-      "RCVR_INVERT_TX"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-betafpv2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "BETAFPV 2.4 GHz",
+        "name": "BETAFPV 2400 TX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "BETAFPV_2400_TX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "BETAFPV_2400_TX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB",
+            "UNLOCK_HIGHER_POWER"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": [{
+            "category": "HiYOUNGER 2.4 GHz",
+            "name": "HiYOUNGER TX2G4 2400 TX",
+            "wikiUrl": "",
+            "abbreviatedName": "HiYOUNGER TX2G4"
+        }]
+    },
+    {
+        "category": "BETAFPV 2.4 GHz",
+        "name": "BETAFPV 2400 TX Micro",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "BETAFPV_2400_TX_MICRO_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "BETAFPV_2400_TX_MICRO_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB",
+            "UNLOCK_HIGHER_POWER"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "BETAFPV 2.4 GHz",
+        "name": "BETAFPV 2400 TX Micro 1000mW",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "BETAFPV_2400_TX_MICRO_1000mw_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "BETAFPV_2400_TX_MICRO_1000mw_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "FEATURE_OPENTX_SYNC",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "UNLOCK_HIGHER_POWER"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "BETAFPV 2.4 GHz",
+        "name": "BETAFPV 2400 RX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "BETAFPV_2400_RX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "BETAFPV_2400_RX_via_WIFI"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "BETAFPV_2400_RX_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "USE_DIVERSITY",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "RCVR_UART_BAUD",
+            "RCVR_INVERT_TX"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-betafpv2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]

--- a/devices/betafpv-2400.json
+++ b/devices/betafpv-2400.json
@@ -1,145 +1,152 @@
-[{
-        "category": "BETAFPV 2.4 GHz",
-        "name": "BETAFPV 2400 TX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "BETAFPV_2400_TX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "BETAFPV_2400_TX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB",
-            "UNLOCK_HIGHER_POWER"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": [{
-            "category": "HiYOUNGER 2.4 GHz",
-            "name": "HiYOUNGER TX2G4 2400 TX",
-            "wikiUrl": "",
-            "abbreviatedName": "HiYOUNGER TX2G4"
-        }]
-    },
-    {
-        "category": "BETAFPV 2.4 GHz",
-        "name": "BETAFPV 2400 TX Micro",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "BETAFPV_2400_TX_MICRO_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "BETAFPV_2400_TX_MICRO_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB",
-            "UNLOCK_HIGHER_POWER"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "BETAFPV 2.4 GHz",
-        "name": "BETAFPV 2400 TX Micro 1000mW",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "BETAFPV_2400_TX_MICRO_1000mw_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "BETAFPV_2400_TX_MICRO_1000mw_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "FEATURE_OPENTX_SYNC",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "UNLOCK_HIGHER_POWER"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "BETAFPV 2.4 GHz",
-        "name": "BETAFPV 2400 RX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "BETAFPV_2400_RX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "BETAFPV_2400_RX_via_WIFI"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "BETAFPV_2400_RX_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "USE_DIVERSITY",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "RCVR_UART_BAUD",
-            "RCVR_INVERT_TX"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-betafpv2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "BETAFPV 2.4 GHz",
+    "name": "BETAFPV 2400 TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "BETAFPV_2400_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "BETAFPV_2400_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB",
+      "UNLOCK_HIGHER_POWER"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": [
+      {
+        "category": "HiYOUNGER 2.4 GHz",
+        "name": "HiYOUNGER TX2G4 2400 TX",
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER TX2G4"
+      }
+    ]
+  },
+  {
+    "category": "BETAFPV 2.4 GHz",
+    "name": "BETAFPV 2400 TX Micro",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "BETAFPV_2400_TX_MICRO_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "BETAFPV_2400_TX_MICRO_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB",
+      "UNLOCK_HIGHER_POWER"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "BETAFPV 2.4 GHz",
+    "name": "BETAFPV 2400 TX Micro 1000mW",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "BETAFPV_2400_TX_MICRO_1000mw_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "BETAFPV_2400_TX_MICRO_1000mw_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "FEATURE_OPENTX_SYNC",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "UNLOCK_HIGHER_POWER"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "BETAFPV 2.4 GHz",
+    "name": "BETAFPV 2400 RX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "BETAFPV_2400_RX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "BETAFPV_2400_RX_via_WIFI"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "BETAFPV_2400_RX_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "USE_DIVERSITY",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "RCVR_UART_BAUD",
+      "RCVR_INVERT_TX"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-betafpv2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/betafpv-900.json
+++ b/devices/betafpv-900.json
@@ -1,122 +1,130 @@
-[{
-        "category": "BETAFPV 900 MHz",
-        "name": "BETAFPV 900 TX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "BETAFPV_900_TX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "BETAFPV_900_TX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "UART_INVERTED",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "UNLOCK_HIGHER_POWER"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv900/",
-        "deviceType": "ExpressLRS",
-        "aliases": [{
-            "category": "HiYOUNGER 900 MHz",
-            "name": "HiYOUNGER 900 TX",
-            "wikiUrl": "",
-            "abbreviatedName": "HiYOUNGER 900 TX"
-        }]
-    },
-    {
-        "category": "BETAFPV 900 MHz",
-        "name": "BETAFPV 900 TX Micro",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "BETAFPV_900_TX_MICRO_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "BETAFPV_900_TX_MICRO_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "UART_INVERTED",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "UNLOCK_HIGHER_POWER"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "BETAFPV 900 MHz",
-        "name": "BETAFPV 900 RX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "BETAFPV_900_RX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "BETAFPV_900_RX_via_WIFI"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "BETAFPV_900_RX_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "RCVR_UART_BAUD",
-            "RCVR_INVERT_TX"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-betafpv900/",
-        "deviceType": "ExpressLRS",
-        "aliases": [{
-            "category": "HiYOUNGER 900 MHz",
-            "name": "HiYOUNGER 900 RX",
-            "wikiUrl": "",
-            "abbreviatedName": "HiYOUNGER 900 RX"
-        }]
-    }
+[
+  {
+    "category": "BETAFPV 900 MHz",
+    "name": "BETAFPV 900 TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "BETAFPV_900_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "BETAFPV_900_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "UART_INVERTED",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "UNLOCK_HIGHER_POWER"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv900/",
+    "deviceType": "ExpressLRS",
+    "aliases": [
+      {
+        "category": "HiYOUNGER 900 MHz",
+        "name": "HiYOUNGER 900 TX",
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER 900 TX"
+      }
+    ]
+  },
+  {
+    "category": "BETAFPV 900 MHz",
+    "name": "BETAFPV 900 TX Micro",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "BETAFPV_900_TX_MICRO_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "BETAFPV_900_TX_MICRO_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "UART_INVERTED",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "UNLOCK_HIGHER_POWER"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "BETAFPV 900 MHz",
+    "name": "BETAFPV 900 RX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "BETAFPV_900_RX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "BETAFPV_900_RX_via_WIFI"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "BETAFPV_900_RX_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "RCVR_UART_BAUD",
+      "RCVR_INVERT_TX"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-betafpv900/",
+    "deviceType": "ExpressLRS",
+    "aliases": [
+      {
+        "category": "HiYOUNGER 900 MHz",
+        "name": "HiYOUNGER 900 RX",
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER 900 RX"
+      }
+    ]
+  }
 ]

--- a/devices/betafpv-900.json
+++ b/devices/betafpv-900.json
@@ -1,130 +1,122 @@
-[
-  {
-    "category": "BETAFPV 900 MHz",
-    "name": "BETAFPV 900 TX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "BETAFPV_900_TX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "BETAFPV_900_TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "UART_INVERTED",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "UNLOCK_HIGHER_POWER"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-betafpv900/",
-    "deviceType": "ExpressLRS",
-    "aliases": [
-      {
-        "category": "HiYOUNGER 900 MHz",
-        "name": "HiYOUNGER 900 TX",
-        "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER 900 TX"
-      }
-    ]
-  },
-  {
-    "category": "BETAFPV 900 MHz",
-    "name": "BETAFPV 900 TX Micro",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "BETAFPV_900_TX_MICRO_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "BETAFPV_900_TX_MICRO_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "UART_INVERTED",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "UNLOCK_HIGHER_POWER"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-betafpv900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "BETAFPV 900 MHz",
-    "name": "BETAFPV 900 RX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "BETAFPV_900_RX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "BETAFPV_900_RX_via_WIFI"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "BETAFPV_900_RX_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "RCVR_UART_BAUD",
-      "RCVR_INVERT_TX"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-betafpv900/",
-    "deviceType": "ExpressLRS",
-    "aliases": [
-      {
-        "category": "HiYOUNGER 900 MHz",
-        "name": "HiYOUNGER 900 RX",
-        "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER 900 RX"
-      }
-    ]
-  }
+[{
+        "category": "BETAFPV 900 MHz",
+        "name": "BETAFPV 900 TX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "BETAFPV_900_TX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "BETAFPV_900_TX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "UART_INVERTED",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "UNLOCK_HIGHER_POWER"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv900/",
+        "deviceType": "ExpressLRS",
+        "aliases": [{
+            "category": "HiYOUNGER 900 MHz",
+            "name": "HiYOUNGER 900 TX",
+            "wikiUrl": "",
+            "abbreviatedName": "HiYOUNGER 900 TX"
+        }]
+    },
+    {
+        "category": "BETAFPV 900 MHz",
+        "name": "BETAFPV 900 TX Micro",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "BETAFPV_900_TX_MICRO_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "BETAFPV_900_TX_MICRO_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "UART_INVERTED",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "UNLOCK_HIGHER_POWER"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "BETAFPV 900 MHz",
+        "name": "BETAFPV 900 RX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "BETAFPV_900_RX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "BETAFPV_900_RX_via_WIFI"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "BETAFPV_900_RX_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "RCVR_UART_BAUD",
+            "RCVR_INVERT_TX"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-betafpv900/",
+        "deviceType": "ExpressLRS",
+        "aliases": [{
+            "category": "HiYOUNGER 900 MHz",
+            "name": "HiYOUNGER 900 RX",
+            "wikiUrl": "",
+            "abbreviatedName": "HiYOUNGER 900 RX"
+        }]
+    }
 ]

--- a/devices/diy-2400.json
+++ b/devices/diy-2400.json
@@ -1,254 +1,246 @@
-[
-  {
-    "category": "DIY 2.4 GHz",
-    "name": "DIY 2400 TX ESP32 SX1280 Mini",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_2400_TX_ESP32_SX1280_Mini_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_2400_TX_ESP32_SX1280_Mini_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "DIY 2.4 GHz",
-    "name": "DIY 2400 TX ESP32 SX1280 E28",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_2400_TX_ESP32_SX1280_E28_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_2400_TX_ESP32_SX1280_E28_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "USE_TX_BACKPACK",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "DIY 2.4 GHz",
-    "name": "DIY 2400 TX ESP32 SX1280 LORA1280F27",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "DIY 2.4 GHz",
-    "name": "DIY 2400 RX ESP8285 SX1280",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_2400_RX_ESP8285_SX1280_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_2400_RX_ESP8285_SX1280_via_WIFI"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "USE_DIVERSITY",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "RCVR_UART_BAUD",
-      "RCVR_INVERT_TX"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-diyreceivers/",
-    "deviceType": "ExpressLRS",
-    "aliases": [
-      {
-        "category": "Flywoo 2.4 GHz",
-        "name": "Flywoo EL24E 2400 RX",
-        "wikiUrl": "",
-        "abbreviatedName": "Flywoo EL24E"
-      },
-      {
-        "category": "Flywoo 2.4 GHz",
-        "name": "Flywoo EL24P 2400 RX",
-        "wikiUrl": "",
-        "abbreviatedName": "Flywoo EL24P"
-      },
-      {
-        "category": "HiYOUNGER 2.4 GHz",
-        "name": "HiYOUNGER SP24S 2400 RX",
-        "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER SP24S"
-      },
-      {
-        "category": "HiYOUNGER 2.4 GHz",
-        "name": "HiYOUNGER EP24S 2400 RX",
-        "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER EP24S"
-      },
-      {
-        "category": "HiYOUNGER 2.4 GHz",
-        "name": "HiYOUNGER RX24T 2400 RX",
-        "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER RX24T"
-      },
-      {
-        "category": "JHEMCU 2.4 GHz",
-        "name": "JHEMCU SP24S 2400 RX",
-        "wikiUrl": "",
-        "abbreviatedName": "JHEMCU SP24S"
-      },
-      {
-        "category": "JHEMCU 2.4 GHz",
-        "name": "JHEMCU EP24S 2400 RX",
-        "wikiUrl": "",
-        "abbreviatedName": "JHEMCU EP24S"
-      },
-      {
-        "category": "JHEMCU 2.4 GHz",
-        "name": "JHEMCU RX24T 2400 RX",
-        "wikiUrl": "",
-        "abbreviatedName": "JHEMCU RX24T"
-      }
-    ]
-  },
-  {
-    "category": "DIY 2.4 GHz",
-    "name": "DIY 2400 RX PWMP",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_2400_RX_PWMP_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_2400_RX_PWMP_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-diyreceivers/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "DIY 2.4 GHz",
-    "name": "DIY 2400 RX STM32 CCG Nano v0 5",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "DIY_2400_RX_STM32_CCG_Nano_v0_5_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "DIY_2400_RX_STM32_CCG_Nano_v0_5_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-diyreceivers/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "DIY 2.4 GHz",
+        "name": "DIY 2400 TX ESP32 SX1280 Mini",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_2400_TX_ESP32_SX1280_Mini_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_2400_TX_ESP32_SX1280_Mini_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "DIY 2.4 GHz",
+        "name": "DIY 2400 TX ESP32 SX1280 E28",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_2400_TX_ESP32_SX1280_E28_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_2400_TX_ESP32_SX1280_E28_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "USE_TX_BACKPACK",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "DIY 2.4 GHz",
+        "name": "DIY 2400 TX ESP32 SX1280 LORA1280F27",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "DIY 2.4 GHz",
+        "name": "DIY 2400 RX ESP8285 SX1280",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_2400_RX_ESP8285_SX1280_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_2400_RX_ESP8285_SX1280_via_WIFI"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "USE_DIVERSITY",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "RCVR_UART_BAUD",
+            "RCVR_INVERT_TX"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
+        "deviceType": "ExpressLRS",
+        "aliases": [{
+                "category": "Flywoo 2.4 GHz",
+                "name": "Flywoo EL24E 2400 RX",
+                "wikiUrl": "",
+                "abbreviatedName": "Flywoo EL24E"
+            },
+            {
+                "category": "Flywoo 2.4 GHz",
+                "name": "Flywoo EL24P 2400 RX",
+                "wikiUrl": "",
+                "abbreviatedName": "Flywoo EL24P"
+            },
+            {
+                "category": "HiYOUNGER 2.4 GHz",
+                "name": "HiYOUNGER SP24S 2400 RX",
+                "wikiUrl": "",
+                "abbreviatedName": "HiYOUNGER SP24S"
+            },
+            {
+                "category": "HiYOUNGER 2.4 GHz",
+                "name": "HiYOUNGER EP24S 2400 RX",
+                "wikiUrl": "",
+                "abbreviatedName": "HiYOUNGER EP24S"
+            },
+            {
+                "category": "HiYOUNGER 2.4 GHz",
+                "name": "HiYOUNGER RX24T 2400 RX",
+                "wikiUrl": "",
+                "abbreviatedName": "HiYOUNGER RX24T"
+            },
+            {
+                "category": "JHEMCU 2.4 GHz",
+                "name": "JHEMCU SP24S 2400 RX",
+                "wikiUrl": "",
+                "abbreviatedName": "JHEMCU SP24S"
+            },
+            {
+                "category": "JHEMCU 2.4 GHz",
+                "name": "JHEMCU EP24S 2400 RX",
+                "wikiUrl": "",
+                "abbreviatedName": "JHEMCU EP24S"
+            },
+            {
+                "category": "JHEMCU 2.4 GHz",
+                "name": "JHEMCU RX24T 2400 RX",
+                "wikiUrl": "",
+                "abbreviatedName": "JHEMCU RX24T"
+            }
+        ]
+    },
+    {
+        "category": "DIY 2.4 GHz",
+        "name": "DIY 2400 RX PWMP",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_2400_RX_PWMP_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_2400_RX_PWMP_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "DIY 2.4 GHz",
+        "name": "DIY 2400 RX STM32 CCG Nano v0 5",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "DIY_2400_RX_STM32_CCG_Nano_v0_5_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "DIY_2400_RX_STM32_CCG_Nano_v0_5_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]

--- a/devices/diy-2400.json
+++ b/devices/diy-2400.json
@@ -1,246 +1,254 @@
-[{
-        "category": "DIY 2.4 GHz",
-        "name": "DIY 2400 TX ESP32 SX1280 Mini",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_2400_TX_ESP32_SX1280_Mini_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_2400_TX_ESP32_SX1280_Mini_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "DIY 2.4 GHz",
-        "name": "DIY 2400 TX ESP32 SX1280 E28",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_2400_TX_ESP32_SX1280_E28_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_2400_TX_ESP32_SX1280_E28_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "USE_TX_BACKPACK",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "DIY 2.4 GHz",
-        "name": "DIY 2400 TX ESP32 SX1280 LORA1280F27",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "DIY 2.4 GHz",
-        "name": "DIY 2400 RX ESP8285 SX1280",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_2400_RX_ESP8285_SX1280_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_2400_RX_ESP8285_SX1280_via_WIFI"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "USE_DIVERSITY",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "RCVR_UART_BAUD",
-            "RCVR_INVERT_TX"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
-        "deviceType": "ExpressLRS",
-        "aliases": [{
-                "category": "Flywoo 2.4 GHz",
-                "name": "Flywoo EL24E 2400 RX",
-                "wikiUrl": "",
-                "abbreviatedName": "Flywoo EL24E"
-            },
-            {
-                "category": "Flywoo 2.4 GHz",
-                "name": "Flywoo EL24P 2400 RX",
-                "wikiUrl": "",
-                "abbreviatedName": "Flywoo EL24P"
-            },
-            {
-                "category": "HiYOUNGER 2.4 GHz",
-                "name": "HiYOUNGER SP24S 2400 RX",
-                "wikiUrl": "",
-                "abbreviatedName": "HiYOUNGER SP24S"
-            },
-            {
-                "category": "HiYOUNGER 2.4 GHz",
-                "name": "HiYOUNGER EP24S 2400 RX",
-                "wikiUrl": "",
-                "abbreviatedName": "HiYOUNGER EP24S"
-            },
-            {
-                "category": "HiYOUNGER 2.4 GHz",
-                "name": "HiYOUNGER RX24T 2400 RX",
-                "wikiUrl": "",
-                "abbreviatedName": "HiYOUNGER RX24T"
-            },
-            {
-                "category": "JHEMCU 2.4 GHz",
-                "name": "JHEMCU SP24S 2400 RX",
-                "wikiUrl": "",
-                "abbreviatedName": "JHEMCU SP24S"
-            },
-            {
-                "category": "JHEMCU 2.4 GHz",
-                "name": "JHEMCU EP24S 2400 RX",
-                "wikiUrl": "",
-                "abbreviatedName": "JHEMCU EP24S"
-            },
-            {
-                "category": "JHEMCU 2.4 GHz",
-                "name": "JHEMCU RX24T 2400 RX",
-                "wikiUrl": "",
-                "abbreviatedName": "JHEMCU RX24T"
-            }
-        ]
-    },
-    {
-        "category": "DIY 2.4 GHz",
-        "name": "DIY 2400 RX PWMP",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_2400_RX_PWMP_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_2400_RX_PWMP_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "DIY 2.4 GHz",
-        "name": "DIY 2400 RX STM32 CCG Nano v0 5",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "DIY_2400_RX_STM32_CCG_Nano_v0_5_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "DIY_2400_RX_STM32_CCG_Nano_v0_5_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "DIY 2.4 GHz",
+    "name": "DIY 2400 TX ESP32 SX1280 Mini",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_2400_TX_ESP32_SX1280_Mini_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_2400_TX_ESP32_SX1280_Mini_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "DIY 2.4 GHz",
+    "name": "DIY 2400 TX ESP32 SX1280 E28",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_2400_TX_ESP32_SX1280_E28_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_2400_TX_ESP32_SX1280_E28_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "USE_TX_BACKPACK",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "DIY 2.4 GHz",
+    "name": "DIY 2400 TX ESP32 SX1280 LORA1280F27",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "DIY 2.4 GHz",
+    "name": "DIY 2400 RX ESP8285 SX1280",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_2400_RX_ESP8285_SX1280_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_2400_RX_ESP8285_SX1280_via_WIFI"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "USE_DIVERSITY",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "RCVR_UART_BAUD",
+      "RCVR_INVERT_TX"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
+    "deviceType": "ExpressLRS",
+    "aliases": [
+      {
+        "category": "Flywoo 2.4 GHz",
+        "name": "Flywoo EL24E 2400 RX",
+        "wikiUrl": "",
+        "abbreviatedName": "Flywoo EL24E"
+      },
+      {
+        "category": "Flywoo 2.4 GHz",
+        "name": "Flywoo EL24P 2400 RX",
+        "wikiUrl": "",
+        "abbreviatedName": "Flywoo EL24P"
+      },
+      {
+        "category": "HiYOUNGER 2.4 GHz",
+        "name": "HiYOUNGER SP24S 2400 RX",
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER SP24S"
+      },
+      {
+        "category": "HiYOUNGER 2.4 GHz",
+        "name": "HiYOUNGER EP24S 2400 RX",
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER EP24S"
+      },
+      {
+        "category": "HiYOUNGER 2.4 GHz",
+        "name": "HiYOUNGER RX24T 2400 RX",
+        "wikiUrl": "",
+        "abbreviatedName": "HiYOUNGER RX24T"
+      },
+      {
+        "category": "JHEMCU 2.4 GHz",
+        "name": "JHEMCU SP24S 2400 RX",
+        "wikiUrl": "",
+        "abbreviatedName": "JHEMCU SP24S"
+      },
+      {
+        "category": "JHEMCU 2.4 GHz",
+        "name": "JHEMCU EP24S 2400 RX",
+        "wikiUrl": "",
+        "abbreviatedName": "JHEMCU EP24S"
+      },
+      {
+        "category": "JHEMCU 2.4 GHz",
+        "name": "JHEMCU RX24T 2400 RX",
+        "wikiUrl": "",
+        "abbreviatedName": "JHEMCU RX24T"
+      }
+    ]
+  },
+  {
+    "category": "DIY 2.4 GHz",
+    "name": "DIY 2400 RX PWMP",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_2400_RX_PWMP_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_2400_RX_PWMP_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "DIY 2.4 GHz",
+    "name": "DIY 2400 RX STM32 CCG Nano v0 5",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "DIY_2400_RX_STM32_CCG_Nano_v0_5_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "DIY_2400_RX_STM32_CCG_Nano_v0_5_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/diy-900.json
+++ b/devices/diy-900.json
@@ -1,210 +1,217 @@
-[{
-        "category": "DIY 900 MHz",
-        "name": "DIY 900 TX TTGO V1 SX127x",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_900_TX_TTGO_V1_SX127x_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_900_TX_TTGO_V1_SX127x_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "UART_INVERTED",
-            "USE_DYNAMIC_POWER",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "DIY 900 MHz",
-        "name": "DIY 900 TX TTGO V2 SX127x",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_900_TX_TTGO_V2_SX127x_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_900_TX_TTGO_V2_SX127x_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_DYNAMIC_POWER",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "DIY 900 MHz",
-        "name": "DIY 900 TX ESP32 SX127x E19",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_900_TX_ESP32_SX127x_E19_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_900_TX_ESP32_SX127x_E19_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "UART_INVERTED",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "UNLOCK_HIGHER_POWER"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "DIY 900 MHz",
-        "name": "DIY 900 TX ESP32 SX127x RFM95",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_900_TX_ESP32_SX127x_RFM95_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_900_TX_ESP32_SX127x_RFM95_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "UART_INVERTED",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "DIY 900 MHz",
-        "name": "DIY 900 RX ESP8285 SX127x",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_900_RX_ESP8285_SX127x_via_UART"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_900_RX_ESP8285_SX127x_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "RCVR_UART_BAUD",
-            "RCVR_INVERT_TX"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "DIY 900 MHz",
-        "name": "DIY 900 RX PWMP",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "DIY_900_RX_PWMP_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "DIY_900_RX_PWMP_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "DIY 900 MHz",
+    "name": "DIY 900 TX TTGO V1 SX127x",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_900_TX_TTGO_V1_SX127x_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_900_TX_TTGO_V1_SX127x_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "UART_INVERTED",
+      "USE_DYNAMIC_POWER",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "DIY 900 MHz",
+    "name": "DIY 900 TX TTGO V2 SX127x",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_900_TX_TTGO_V2_SX127x_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_900_TX_TTGO_V2_SX127x_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_DYNAMIC_POWER",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "DIY 900 MHz",
+    "name": "DIY 900 TX ESP32 SX127x E19",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_900_TX_ESP32_SX127x_E19_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_900_TX_ESP32_SX127x_E19_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "UART_INVERTED",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "UNLOCK_HIGHER_POWER"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "DIY 900 MHz",
+    "name": "DIY 900 TX ESP32 SX127x RFM95",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_900_TX_ESP32_SX127x_RFM95_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_900_TX_ESP32_SX127x_RFM95_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "UART_INVERTED",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "DIY 900 MHz",
+    "name": "DIY 900 RX ESP8285 SX127x",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_900_RX_ESP8285_SX127x_via_UART"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_900_RX_ESP8285_SX127x_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "RCVR_UART_BAUD",
+      "RCVR_INVERT_TX"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "DIY 900 MHz",
+    "name": "DIY 900 RX PWMP",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "DIY_900_RX_PWMP_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "DIY_900_RX_PWMP_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/diy-900.json
+++ b/devices/diy-900.json
@@ -1,217 +1,210 @@
-[
-  {
-    "category": "DIY 900 MHz",
-    "name": "DIY 900 TX TTGO V1 SX127x",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_900_TX_TTGO_V1_SX127x_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_900_TX_TTGO_V1_SX127x_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "UART_INVERTED",
-      "USE_DYNAMIC_POWER",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "DIY 900 MHz",
-    "name": "DIY 900 TX TTGO V2 SX127x",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_900_TX_TTGO_V2_SX127x_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_900_TX_TTGO_V2_SX127x_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_DYNAMIC_POWER",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "DIY 900 MHz",
-    "name": "DIY 900 TX ESP32 SX127x E19",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_900_TX_ESP32_SX127x_E19_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_900_TX_ESP32_SX127x_E19_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "UART_INVERTED",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "UNLOCK_HIGHER_POWER"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "DIY 900 MHz",
-    "name": "DIY 900 TX ESP32 SX127x RFM95",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_900_TX_ESP32_SX127x_RFM95_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_900_TX_ESP32_SX127x_RFM95_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "UART_INVERTED",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-diy900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "DIY 900 MHz",
-    "name": "DIY 900 RX ESP8285 SX127x",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_900_RX_ESP8285_SX127x_via_UART"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_900_RX_ESP8285_SX127x_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "RCVR_UART_BAUD",
-      "RCVR_INVERT_TX"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-diyreceivers900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "DIY 900 MHz",
-    "name": "DIY 900 RX PWMP",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "DIY_900_RX_PWMP_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "DIY_900_RX_PWMP_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-diyreceivers900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "DIY 900 MHz",
+        "name": "DIY 900 TX TTGO V1 SX127x",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_900_TX_TTGO_V1_SX127x_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_900_TX_TTGO_V1_SX127x_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "UART_INVERTED",
+            "USE_DYNAMIC_POWER",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "DIY 900 MHz",
+        "name": "DIY 900 TX TTGO V2 SX127x",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_900_TX_TTGO_V2_SX127x_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_900_TX_TTGO_V2_SX127x_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_DYNAMIC_POWER",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "DIY 900 MHz",
+        "name": "DIY 900 TX ESP32 SX127x E19",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_900_TX_ESP32_SX127x_E19_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_900_TX_ESP32_SX127x_E19_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "UART_INVERTED",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "UNLOCK_HIGHER_POWER"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "DIY 900 MHz",
+        "name": "DIY 900 TX ESP32 SX127x RFM95",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_900_TX_ESP32_SX127x_RFM95_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_900_TX_ESP32_SX127x_RFM95_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "UART_INVERTED",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "DIY 900 MHz",
+        "name": "DIY 900 RX ESP8285 SX127x",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_900_RX_ESP8285_SX127x_via_UART"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_900_RX_ESP8285_SX127x_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "RCVR_UART_BAUD",
+            "RCVR_INVERT_TX"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "DIY 900 MHz",
+        "name": "DIY 900 RX PWMP",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "DIY_900_RX_PWMP_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "DIY_900_RX_PWMP_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]

--- a/devices/frsky-900.json
+++ b/devices/frsky-900.json
@@ -1,258 +1,248 @@
-[
-  {
-    "category": "Frsky R9",
-    "name": "Frsky TX R9M",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "Frsky_TX_R9M_via_STLINK"
-      },
-      {
-        "flashingMethod": "Stock_BL",
-        "name": "Frsky_TX_R9M_via_stock_BL"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "Frsky_TX_R9M_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_ESP8266_BACKPACK",
-      "JUST_BEEP_ONCE",
-      "DISABLE_STARTUP_BEEP",
-      "DISABLE_ALL_BEEPS",
-      "MY_STARTUP_MELODY",
-      "USE_DYNAMIC_POWER",
-      "R9M_UNLOCK_HIGHER_POWER",
-      "UNLOCK_HIGHER_POWER",
-      "USE_TX_BACKPACK"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-r9m/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Frsky R9",
-    "name": "Frsky TX R9M LITE",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "Frsky_TX_R9M_LITE_via_STLINK"
-      },
-      {
-        "flashingMethod": "Stock_BL",
-        "name": "Frsky_TX_R9M_LITE_via_stock_BL"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "JUST_BEEP_ONCE",
-      "DISABLE_STARTUP_BEEP",
-      "DISABLE_ALL_BEEPS",
-      "USE_DYNAMIC_POWER"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-r9m/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Frsky R9",
-    "name": "Frsky TX R9M LITE PRO",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "Frsky_TX_R9M_LITE_PRO_via_STLINK"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "UNLOCK_HIGHER_POWER",
-      "JUST_BEEP_ONCE",
-      "DISABLE_STARTUP_BEEP",
-      "DISABLE_ALL_BEEPS",
-      "USE_DYNAMIC_POWER"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-r9m/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Frsky R9",
-    "name": "Frsky RX R9MM R9MINI",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "Frsky_RX_R9MM_R9MINI_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "Frsky_RX_R9MM_R9MINI_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_R9MM_R9MINI_SBUS",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-r9receivers/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Frsky R9",
-    "name": "Frsky RX R9SLIMPLUS",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "Frsky_RX_R9SLIMPLUS_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "Frsky_RX_R9SLIMPLUS_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_DIVERSITY",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-r9receivers/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Frsky R9",
-    "name": "Frsky RX R9SLIM",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "Frsky_RX_R9SLIM_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "Frsky_RX_R9SLIM_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-r9receivers/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Frsky R9",
-    "name": "Frsky RX R9SLIMPLUS OTA",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "Frsky_RX_R9SLIMPLUS_OTA_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "Frsky_RX_R9SLIMPLUS_OTA_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_DIVERSITY",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-r9receivers/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Frsky R9",
-    "name": "Frsky RX R9MX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "Frsky_RX_R9MX_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "Frsky_RX_R9MX_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-r9receivers/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "Frsky R9",
+        "name": "Frsky TX R9M",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "Frsky_TX_R9M_via_STLINK"
+            },
+            {
+                "flashingMethod": "Stock_BL",
+                "name": "Frsky_TX_R9M_via_stock_BL"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "Frsky_TX_R9M_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_ESP8266_BACKPACK",
+            "JUST_BEEP_ONCE",
+            "DISABLE_STARTUP_BEEP",
+            "DISABLE_ALL_BEEPS",
+            "MY_STARTUP_MELODY",
+            "USE_DYNAMIC_POWER",
+            "R9M_UNLOCK_HIGHER_POWER",
+            "UNLOCK_HIGHER_POWER",
+            "USE_TX_BACKPACK"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Frsky R9",
+        "name": "Frsky TX R9M LITE",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "Frsky_TX_R9M_LITE_via_STLINK"
+            },
+            {
+                "flashingMethod": "Stock_BL",
+                "name": "Frsky_TX_R9M_LITE_via_stock_BL"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "JUST_BEEP_ONCE",
+            "DISABLE_STARTUP_BEEP",
+            "DISABLE_ALL_BEEPS",
+            "USE_DYNAMIC_POWER"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Frsky R9",
+        "name": "Frsky TX R9M LITE PRO",
+        "targets": [{
+            "flashingMethod": "STLink",
+            "name": "Frsky_TX_R9M_LITE_PRO_via_STLINK"
+        }],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "UNLOCK_HIGHER_POWER",
+            "JUST_BEEP_ONCE",
+            "DISABLE_STARTUP_BEEP",
+            "DISABLE_ALL_BEEPS",
+            "USE_DYNAMIC_POWER"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Frsky R9",
+        "name": "Frsky RX R9MM R9MINI",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "Frsky_RX_R9MM_R9MINI_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "Frsky_RX_R9MM_R9MINI_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_R9MM_R9MINI_SBUS",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Frsky R9",
+        "name": "Frsky RX R9SLIMPLUS",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "Frsky_RX_R9SLIMPLUS_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "Frsky_RX_R9SLIMPLUS_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_DIVERSITY",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Frsky R9",
+        "name": "Frsky RX R9SLIM",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "Frsky_RX_R9SLIM_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "Frsky_RX_R9SLIM_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Frsky R9",
+        "name": "Frsky RX R9SLIMPLUS OTA",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "Frsky_RX_R9SLIMPLUS_OTA_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "Frsky_RX_R9SLIMPLUS_OTA_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_DIVERSITY",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Frsky R9",
+        "name": "Frsky RX R9MX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "Frsky_RX_R9MX_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "Frsky_RX_R9MX_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]

--- a/devices/frsky-900.json
+++ b/devices/frsky-900.json
@@ -1,248 +1,258 @@
-[{
-        "category": "Frsky R9",
-        "name": "Frsky TX R9M",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "Frsky_TX_R9M_via_STLINK"
-            },
-            {
-                "flashingMethod": "Stock_BL",
-                "name": "Frsky_TX_R9M_via_stock_BL"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "Frsky_TX_R9M_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_ESP8266_BACKPACK",
-            "JUST_BEEP_ONCE",
-            "DISABLE_STARTUP_BEEP",
-            "DISABLE_ALL_BEEPS",
-            "MY_STARTUP_MELODY",
-            "USE_DYNAMIC_POWER",
-            "R9M_UNLOCK_HIGHER_POWER",
-            "UNLOCK_HIGHER_POWER",
-            "USE_TX_BACKPACK"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Frsky R9",
-        "name": "Frsky TX R9M LITE",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "Frsky_TX_R9M_LITE_via_STLINK"
-            },
-            {
-                "flashingMethod": "Stock_BL",
-                "name": "Frsky_TX_R9M_LITE_via_stock_BL"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "JUST_BEEP_ONCE",
-            "DISABLE_STARTUP_BEEP",
-            "DISABLE_ALL_BEEPS",
-            "USE_DYNAMIC_POWER"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Frsky R9",
-        "name": "Frsky TX R9M LITE PRO",
-        "targets": [{
-            "flashingMethod": "STLink",
-            "name": "Frsky_TX_R9M_LITE_PRO_via_STLINK"
-        }],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "UNLOCK_HIGHER_POWER",
-            "JUST_BEEP_ONCE",
-            "DISABLE_STARTUP_BEEP",
-            "DISABLE_ALL_BEEPS",
-            "USE_DYNAMIC_POWER"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Frsky R9",
-        "name": "Frsky RX R9MM R9MINI",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "Frsky_RX_R9MM_R9MINI_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "Frsky_RX_R9MM_R9MINI_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_R9MM_R9MINI_SBUS",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Frsky R9",
-        "name": "Frsky RX R9SLIMPLUS",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "Frsky_RX_R9SLIMPLUS_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "Frsky_RX_R9SLIMPLUS_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_DIVERSITY",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Frsky R9",
-        "name": "Frsky RX R9SLIM",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "Frsky_RX_R9SLIM_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "Frsky_RX_R9SLIM_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Frsky R9",
-        "name": "Frsky RX R9SLIMPLUS OTA",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "Frsky_RX_R9SLIMPLUS_OTA_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "Frsky_RX_R9SLIMPLUS_OTA_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_DIVERSITY",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Frsky R9",
-        "name": "Frsky RX R9MX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "Frsky_RX_R9MX_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "Frsky_RX_R9MX_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "Frsky R9",
+    "name": "Frsky TX R9M",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "Frsky_TX_R9M_via_STLINK"
+      },
+      {
+        "flashingMethod": "Stock_BL",
+        "name": "Frsky_TX_R9M_via_stock_BL"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "Frsky_TX_R9M_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_ESP8266_BACKPACK",
+      "JUST_BEEP_ONCE",
+      "DISABLE_STARTUP_BEEP",
+      "DISABLE_ALL_BEEPS",
+      "MY_STARTUP_MELODY",
+      "USE_DYNAMIC_POWER",
+      "R9M_UNLOCK_HIGHER_POWER",
+      "UNLOCK_HIGHER_POWER",
+      "USE_TX_BACKPACK"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Frsky R9",
+    "name": "Frsky TX R9M LITE",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "Frsky_TX_R9M_LITE_via_STLINK"
+      },
+      {
+        "flashingMethod": "Stock_BL",
+        "name": "Frsky_TX_R9M_LITE_via_stock_BL"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "JUST_BEEP_ONCE",
+      "DISABLE_STARTUP_BEEP",
+      "DISABLE_ALL_BEEPS",
+      "USE_DYNAMIC_POWER"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Frsky R9",
+    "name": "Frsky TX R9M LITE PRO",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "Frsky_TX_R9M_LITE_PRO_via_STLINK"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "UNLOCK_HIGHER_POWER",
+      "JUST_BEEP_ONCE",
+      "DISABLE_STARTUP_BEEP",
+      "DISABLE_ALL_BEEPS",
+      "USE_DYNAMIC_POWER"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Frsky R9",
+    "name": "Frsky RX R9MM R9MINI",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "Frsky_RX_R9MM_R9MINI_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "Frsky_RX_R9MM_R9MINI_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_R9MM_R9MINI_SBUS",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Frsky R9",
+    "name": "Frsky RX R9SLIMPLUS",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "Frsky_RX_R9SLIMPLUS_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "Frsky_RX_R9SLIMPLUS_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_DIVERSITY",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Frsky R9",
+    "name": "Frsky RX R9SLIM",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "Frsky_RX_R9SLIM_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "Frsky_RX_R9SLIM_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Frsky R9",
+    "name": "Frsky RX R9SLIMPLUS OTA",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "Frsky_RX_R9SLIMPLUS_OTA_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "Frsky_RX_R9SLIMPLUS_OTA_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_DIVERSITY",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Frsky R9",
+    "name": "Frsky RX R9MX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "Frsky_RX_R9MX_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "Frsky_RX_R9MX_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/ghost-2400.json
+++ b/devices/ghost-2400.json
@@ -1,97 +1,93 @@
-[
-  {
-    "category": "ImmersionRC Ghost",
-    "name": "GHOST 2400 TX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "GHOST_2400_TX_via_STLINK"
-      },
-      {
-        "flashingMethod": "Radio",
-        "name": "GHOST_2400_TX_via_STLINK"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "USE_DYNAMIC_POWER",
-      "JUST_BEEP_ONCE",
-      "DISABLE_STARTUP_BEEP",
-      "DISABLE_ALL_BEEPS",
-      "MY_STARTUP_MELODY"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-ghost2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "ImmersionRC Ghost",
-    "name": "GHOST 2400 TX LITE",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "GHOST_2400_TX_LITE_via_STLINK"
-      },
-      {
-        "flashingMethod": "Radio",
-        "name": "GHOST_2400_TX_LITE_via_STLINK"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "USE_DYNAMIC_POWER",
-      "JUST_BEEP_ONCE",
-      "DISABLE_STARTUP_BEEP",
-      "DISABLE_ALL_BEEPS",
-      "MY_STARTUP_MELODY"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-ghost2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "ImmersionRC Ghost",
-    "name": "GHOST ATTO 2400 RX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "GHOST_ATTO_2400_RX_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "GHOST_ATTO_2400_RX_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-ghost2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "ImmersionRC Ghost",
+        "name": "GHOST 2400 TX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "GHOST_2400_TX_via_STLINK"
+            },
+            {
+                "flashingMethod": "Radio",
+                "name": "GHOST_2400_TX_via_STLINK"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "USE_DYNAMIC_POWER",
+            "JUST_BEEP_ONCE",
+            "DISABLE_STARTUP_BEEP",
+            "DISABLE_ALL_BEEPS",
+            "MY_STARTUP_MELODY"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-ghost2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "ImmersionRC Ghost",
+        "name": "GHOST 2400 TX LITE",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "GHOST_2400_TX_LITE_via_STLINK"
+            },
+            {
+                "flashingMethod": "Radio",
+                "name": "GHOST_2400_TX_LITE_via_STLINK"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "USE_DYNAMIC_POWER",
+            "JUST_BEEP_ONCE",
+            "DISABLE_STARTUP_BEEP",
+            "DISABLE_ALL_BEEPS",
+            "MY_STARTUP_MELODY"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-ghost2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "ImmersionRC Ghost",
+        "name": "GHOST ATTO 2400 RX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "GHOST_ATTO_2400_RX_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "GHOST_ATTO_2400_RX_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-ghost2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]

--- a/devices/ghost-2400.json
+++ b/devices/ghost-2400.json
@@ -1,93 +1,97 @@
-[{
-        "category": "ImmersionRC Ghost",
-        "name": "GHOST 2400 TX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "GHOST_2400_TX_via_STLINK"
-            },
-            {
-                "flashingMethod": "Radio",
-                "name": "GHOST_2400_TX_via_STLINK"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "USE_DYNAMIC_POWER",
-            "JUST_BEEP_ONCE",
-            "DISABLE_STARTUP_BEEP",
-            "DISABLE_ALL_BEEPS",
-            "MY_STARTUP_MELODY"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-ghost2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "ImmersionRC Ghost",
-        "name": "GHOST 2400 TX LITE",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "GHOST_2400_TX_LITE_via_STLINK"
-            },
-            {
-                "flashingMethod": "Radio",
-                "name": "GHOST_2400_TX_LITE_via_STLINK"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "USE_DYNAMIC_POWER",
-            "JUST_BEEP_ONCE",
-            "DISABLE_STARTUP_BEEP",
-            "DISABLE_ALL_BEEPS",
-            "MY_STARTUP_MELODY"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-ghost2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "ImmersionRC Ghost",
-        "name": "GHOST ATTO 2400 RX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "GHOST_ATTO_2400_RX_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "GHOST_ATTO_2400_RX_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-ghost2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "ImmersionRC Ghost",
+    "name": "GHOST 2400 TX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "GHOST_2400_TX_via_STLINK"
+      },
+      {
+        "flashingMethod": "Radio",
+        "name": "GHOST_2400_TX_via_STLINK"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "USE_DYNAMIC_POWER",
+      "JUST_BEEP_ONCE",
+      "DISABLE_STARTUP_BEEP",
+      "DISABLE_ALL_BEEPS",
+      "MY_STARTUP_MELODY"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-ghost2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "ImmersionRC Ghost",
+    "name": "GHOST 2400 TX LITE",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "GHOST_2400_TX_LITE_via_STLINK"
+      },
+      {
+        "flashingMethod": "Radio",
+        "name": "GHOST_2400_TX_LITE_via_STLINK"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "USE_DYNAMIC_POWER",
+      "JUST_BEEP_ONCE",
+      "DISABLE_STARTUP_BEEP",
+      "DISABLE_ALL_BEEPS",
+      "MY_STARTUP_MELODY"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-ghost2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "ImmersionRC Ghost",
+    "name": "GHOST ATTO 2400 RX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "GHOST_ATTO_2400_RX_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "GHOST_ATTO_2400_RX_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-ghost2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/happymodel-2400.json
+++ b/devices/happymodel-2400.json
@@ -1,173 +1,167 @@
-[
-  {
-    "category": "Happymodel 2.4 GHz",
-    "name": "HappyModel ES24TX 2400 TX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "HappyModel_ES24TX_2400_TX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "HappyModel_ES24TX_2400_TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-es24tx/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Happymodel 2.4 GHz",
-    "name": "HappyModel ES24TX Slim Pro 2400 TX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "HappyModel_ES24TX_Slim_Pro_2400_TX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "HappyModel_ES24TX_Slim_Pro_2400_TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-es24tx/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Happymodel 2.4 GHz",
-    "name": "HM ES24TX Pro Series 2400 TX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "HappyModel_ES24TX_Pro_Series_2400_TX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "HappyModel_ES24TX_Pro_Series_2400_TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-es24tx/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Happymodel 2.4 GHz",
-    "name": "HappyModel EP 2400 RX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "HappyModel_EP_2400_RX_via_UART"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "HappyModel_EP_2400_RX_via_BetaflightPassthrough"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "HappyModel_EP_2400_RX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "RCVR_UART_BAUD",
-      "RCVR_INVERT_TX"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-hmep2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Happymodel 2.4 GHz",
-    "name": "HappyModel PP 2400 RX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "HappyModel_PP_2400_RX_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "HappyModel_PP_2400_RX_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-hmpp2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "Happymodel 2.4 GHz",
+        "name": "HappyModel ES24TX 2400 TX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "HappyModel_ES24TX_2400_TX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "HappyModel_ES24TX_2400_TX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Happymodel 2.4 GHz",
+        "name": "HappyModel ES24TX Slim Pro 2400 TX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "HappyModel_ES24TX_Slim_Pro_2400_TX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "HappyModel_ES24TX_Slim_Pro_2400_TX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Happymodel 2.4 GHz",
+        "name": "HM ES24TX Pro Series 2400 TX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "HappyModel_ES24TX_Pro_Series_2400_TX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "HappyModel_ES24TX_Pro_Series_2400_TX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "WS2812_IS_GRB"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Happymodel 2.4 GHz",
+        "name": "HappyModel EP 2400 RX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "HappyModel_EP_2400_RX_via_UART"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "HappyModel_EP_2400_RX_via_BetaflightPassthrough"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "HappyModel_EP_2400_RX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "RCVR_UART_BAUD",
+            "RCVR_INVERT_TX"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmep2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Happymodel 2.4 GHz",
+        "name": "HappyModel PP 2400 RX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "HappyModel_PP_2400_RX_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "HappyModel_PP_2400_RX_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmpp2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]

--- a/devices/happymodel-2400.json
+++ b/devices/happymodel-2400.json
@@ -1,167 +1,173 @@
-[{
-        "category": "Happymodel 2.4 GHz",
-        "name": "HappyModel ES24TX 2400 TX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "HappyModel_ES24TX_2400_TX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "HappyModel_ES24TX_2400_TX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Happymodel 2.4 GHz",
-        "name": "HappyModel ES24TX Slim Pro 2400 TX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "HappyModel_ES24TX_Slim_Pro_2400_TX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "HappyModel_ES24TX_Slim_Pro_2400_TX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Happymodel 2.4 GHz",
-        "name": "HM ES24TX Pro Series 2400 TX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "HappyModel_ES24TX_Pro_Series_2400_TX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "HappyModel_ES24TX_Pro_Series_2400_TX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "WS2812_IS_GRB"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Happymodel 2.4 GHz",
-        "name": "HappyModel EP 2400 RX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "HappyModel_EP_2400_RX_via_UART"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "HappyModel_EP_2400_RX_via_BetaflightPassthrough"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "HappyModel_EP_2400_RX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "RCVR_UART_BAUD",
-            "RCVR_INVERT_TX"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmep2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Happymodel 2.4 GHz",
-        "name": "HappyModel PP 2400 RX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "HappyModel_PP_2400_RX_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "HappyModel_PP_2400_RX_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmpp2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "Happymodel 2.4 GHz",
+    "name": "HappyModel ES24TX 2400 TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "HappyModel_ES24TX_2400_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "HappyModel_ES24TX_2400_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Happymodel 2.4 GHz",
+    "name": "HappyModel ES24TX Slim Pro 2400 TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "HappyModel_ES24TX_Slim_Pro_2400_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "HappyModel_ES24TX_Slim_Pro_2400_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Happymodel 2.4 GHz",
+    "name": "HM ES24TX Pro Series 2400 TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "HappyModel_ES24TX_Pro_Series_2400_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "HappyModel_ES24TX_Pro_Series_2400_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Happymodel 2.4 GHz",
+    "name": "HappyModel EP 2400 RX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "HappyModel_EP_2400_RX_via_UART"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "HappyModel_EP_2400_RX_via_BetaflightPassthrough"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "HappyModel_EP_2400_RX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "RCVR_UART_BAUD",
+      "RCVR_INVERT_TX"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmep2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Happymodel 2.4 GHz",
+    "name": "HappyModel PP 2400 RX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "HappyModel_PP_2400_RX_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "HappyModel_PP_2400_RX_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmpp2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/happymodel-900.json
+++ b/devices/happymodel-900.json
@@ -1,145 +1,150 @@
-[{
-        "category": "Happymodel 900 MHz",
-        "name": "HappyModel TX ES900TX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "HappyModel_TX_ES900TX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "HappyModel_TX_ES900TX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "BLE_HID_JOYSTICK",
-            "UNLOCK_HIGHER_POWER",
-            "USE_DYNAMIC_POWER",
-            "UART_INVERTED",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es900tx/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Happymodel 900 MHz",
-        "name": "HappyModel RX ES900RX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "HappyModel_RX_ES900RX_via_UART"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "HappyModel_RX_ES900RX_via_BetaflightPassthrough"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "HappyModel_RX_ES900RX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "RCVR_UART_BAUD",
-            "RCVR_INVERT_TX"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmes900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Happymodel 900 MHz",
-        "name": "HappyModel TX ES915TX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "HappyModel_TX_ES915TX_via_STLINK"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "HappyModel_TX_ES915TX_via_WIFI"
-            },
-            {
-                "flashingMethod": "Stock_BL",
-                "name": "HappyModel_TX_ES915TX_via_stock_BL"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "UNLOCK_HIGHER_POWER",
-            "JUST_BEEP_ONCE",
-            "DISABLE_STARTUP_BEEP",
-            "DISABLE_ALL_BEEPS",
-            "MY_STARTUP_MELODY",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es900tx/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Happymodel 900 MHz",
-        "name": "HappyModel RX ES915RX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "HappyModel_RX_ES915RX_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "HappyModel_RX_ES915RX_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmes900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "Happymodel 900 MHz",
+    "name": "HappyModel TX ES900TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "HappyModel_TX_ES900TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "HappyModel_TX_ES900TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "BLE_HID_JOYSTICK",
+      "UNLOCK_HIGHER_POWER",
+      "USE_DYNAMIC_POWER",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es900tx/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Happymodel 900 MHz",
+    "name": "HappyModel RX ES900RX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "HappyModel_RX_ES900RX_via_UART"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "HappyModel_RX_ES900RX_via_BetaflightPassthrough"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "HappyModel_RX_ES900RX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "RCVR_UART_BAUD",
+      "RCVR_INVERT_TX"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmes900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Happymodel 900 MHz",
+    "name": "HappyModel TX ES915TX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "HappyModel_TX_ES915TX_via_STLINK"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "HappyModel_TX_ES915TX_via_WIFI"
+      },
+      {
+        "flashingMethod": "Stock_BL",
+        "name": "HappyModel_TX_ES915TX_via_stock_BL"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "UNLOCK_HIGHER_POWER",
+      "JUST_BEEP_ONCE",
+      "DISABLE_STARTUP_BEEP",
+      "DISABLE_ALL_BEEPS",
+      "MY_STARTUP_MELODY",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es900tx/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Happymodel 900 MHz",
+    "name": "HappyModel RX ES915RX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "HappyModel_RX_ES915RX_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "HappyModel_RX_ES915RX_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmes900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/happymodel-900.json
+++ b/devices/happymodel-900.json
@@ -1,150 +1,145 @@
-[
-  {
-    "category": "Happymodel 900 MHz",
-    "name": "HappyModel TX ES900TX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "HappyModel_TX_ES900TX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "HappyModel_TX_ES900TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "BLE_HID_JOYSTICK",
-      "UNLOCK_HIGHER_POWER",
-      "USE_DYNAMIC_POWER",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-es900tx/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Happymodel 900 MHz",
-    "name": "HappyModel RX ES900RX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "HappyModel_RX_ES900RX_via_UART"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "HappyModel_RX_ES900RX_via_BetaflightPassthrough"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "HappyModel_RX_ES900RX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "RCVR_UART_BAUD",
-      "RCVR_INVERT_TX"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-hmes900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Happymodel 900 MHz",
-    "name": "HappyModel TX ES915TX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "HappyModel_TX_ES915TX_via_STLINK"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "HappyModel_TX_ES915TX_via_WIFI"
-      },
-      {
-        "flashingMethod": "Stock_BL",
-        "name": "HappyModel_TX_ES915TX_via_stock_BL"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "UNLOCK_HIGHER_POWER",
-      "JUST_BEEP_ONCE",
-      "DISABLE_STARTUP_BEEP",
-      "DISABLE_ALL_BEEPS",
-      "MY_STARTUP_MELODY",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-es900tx/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Happymodel 900 MHz",
-    "name": "HappyModel RX ES915RX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "HappyModel_RX_ES915RX_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "HappyModel_RX_ES915RX_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-hmes900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "Happymodel 900 MHz",
+        "name": "HappyModel TX ES900TX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "HappyModel_TX_ES900TX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "HappyModel_TX_ES900TX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "BLE_HID_JOYSTICK",
+            "UNLOCK_HIGHER_POWER",
+            "USE_DYNAMIC_POWER",
+            "UART_INVERTED",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es900tx/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Happymodel 900 MHz",
+        "name": "HappyModel RX ES900RX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "HappyModel_RX_ES900RX_via_UART"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "HappyModel_RX_ES900RX_via_BetaflightPassthrough"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "HappyModel_RX_ES900RX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "RCVR_UART_BAUD",
+            "RCVR_INVERT_TX"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmes900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Happymodel 900 MHz",
+        "name": "HappyModel TX ES915TX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "HappyModel_TX_ES915TX_via_STLINK"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "HappyModel_TX_ES915TX_via_WIFI"
+            },
+            {
+                "flashingMethod": "Stock_BL",
+                "name": "HappyModel_TX_ES915TX_via_stock_BL"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "UNLOCK_HIGHER_POWER",
+            "JUST_BEEP_ONCE",
+            "DISABLE_STARTUP_BEEP",
+            "DISABLE_ALL_BEEPS",
+            "MY_STARTUP_MELODY",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es900tx/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Happymodel 900 MHz",
+        "name": "HappyModel RX ES915RX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "HappyModel_RX_ES915RX_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "HappyModel_RX_ES915RX_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmes900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]

--- a/devices/jumper-900.json
+++ b/devices/jumper-900.json
@@ -1,31 +1,28 @@
-[
-  {
+[{
     "category": "Jumper R900",
     "name": "Jumper RX R900MINI",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "Jumper_RX_R900MINI_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "Jumper_RX_R900MINI_via_BetaflightPassthrough"
-      }
+    "targets": [{
+            "flashingMethod": "STLink",
+            "name": "Jumper_RX_R900MINI_via_STLINK"
+        },
+        {
+            "flashingMethod": "BetaflightPassthrough",
+            "name": "Jumper_RX_R900MINI_via_BetaflightPassthrough"
+        }
     ],
     "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "RCVR_UART_BAUD"
+        "REGULATORY_DOMAIN_AU_915",
+        "REGULATORY_DOMAIN_EU_868",
+        "REGULATORY_DOMAIN_FCC_915",
+        "REGULATORY_DOMAIN_IN_866",
+        "BINDING_PHRASE",
+        "HYBRID_SWITCHES_8",
+        "ENABLE_TELEMETRY",
+        "ARM_CHANNEL",
+        "LOCK_ON_FIRST_CONNECTION",
+        "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-jumper900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-jumper900/",
     "deviceType": "ExpressLRS",
     "aliases": []
-  }
-]
+}]

--- a/devices/jumper-900.json
+++ b/devices/jumper-900.json
@@ -1,28 +1,31 @@
-[{
+[
+  {
     "category": "Jumper R900",
     "name": "Jumper RX R900MINI",
-    "targets": [{
-            "flashingMethod": "STLink",
-            "name": "Jumper_RX_R900MINI_via_STLINK"
-        },
-        {
-            "flashingMethod": "BetaflightPassthrough",
-            "name": "Jumper_RX_R900MINI_via_BetaflightPassthrough"
-        }
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "Jumper_RX_R900MINI_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "Jumper_RX_R900MINI_via_BetaflightPassthrough"
+      }
     ],
     "userDefines": [
-        "REGULATORY_DOMAIN_AU_915",
-        "REGULATORY_DOMAIN_EU_868",
-        "REGULATORY_DOMAIN_FCC_915",
-        "REGULATORY_DOMAIN_IN_866",
-        "BINDING_PHRASE",
-        "HYBRID_SWITCHES_8",
-        "ENABLE_TELEMETRY",
-        "ARM_CHANNEL",
-        "LOCK_ON_FIRST_CONNECTION",
-        "RCVR_UART_BAUD"
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "RCVR_UART_BAUD"
     ],
     "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-jumper900/",
     "deviceType": "ExpressLRS",
     "aliases": []
-}]
+  }
+]

--- a/devices/matek-2400.json
+++ b/devices/matek-2400.json
@@ -1,69 +1,66 @@
-[
-  {
-    "category": "Matek 2.4 GHz",
-    "name": "Matek 2400 RX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "MATEK_2400_RX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "MATEK_2400_RX_via_WIFI"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "MATEK_2400_RX_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "USE_DIVERSITY",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "RCVR_UART_BAUD",
-      "RCVR_INVERT_TX"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-matek2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Matek 2.4 GHz",
-    "name": "Matek 2400 RX PWM",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "MATEK_2400_RX_PWM_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "MATEK_2400_RX_PWM_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "Matek 2.4 GHz",
+        "name": "Matek 2400 RX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "MATEK_2400_RX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "MATEK_2400_RX_via_WIFI"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "MATEK_2400_RX_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "USE_DIVERSITY",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "RCVR_UART_BAUD",
+            "RCVR_INVERT_TX"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-matek2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "Matek 2.4 GHz",
+        "name": "Matek 2400 RX PWM",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "MATEK_2400_RX_PWM_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "MATEK_2400_RX_PWM_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]

--- a/devices/matek-2400.json
+++ b/devices/matek-2400.json
@@ -1,66 +1,69 @@
-[{
-        "category": "Matek 2.4 GHz",
-        "name": "Matek 2400 RX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "MATEK_2400_RX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "MATEK_2400_RX_via_WIFI"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "MATEK_2400_RX_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "USE_DIVERSITY",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "RCVR_UART_BAUD",
-            "RCVR_INVERT_TX"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-matek2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "Matek 2.4 GHz",
-        "name": "Matek 2400 RX PWM",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "MATEK_2400_RX_PWM_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "MATEK_2400_RX_PWM_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "Matek 2.4 GHz",
+    "name": "Matek 2400 RX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "MATEK_2400_RX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "MATEK_2400_RX_via_WIFI"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "MATEK_2400_RX_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "USE_DIVERSITY",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "RCVR_UART_BAUD",
+      "RCVR_INVERT_TX"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-matek2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "Matek 2.4 GHz",
+    "name": "Matek 2400 RX PWM",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "MATEK_2400_RX_PWM_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "MATEK_2400_RX_PWM_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/namimnorc-2400.json
+++ b/devices/namimnorc-2400.json
@@ -1,131 +1,136 @@
-[{
-        "category": "NamimnoRC FLASH 2.4 GHz",
-        "name": "NamimnoRC FLASH 2400 TX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "NamimnoRC_FLASH_2400_TX_via_STLINK"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "NamimnoRC_FLASH_2400_TX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-flash2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "NamimnoRC FLASH 2.4 GHz",
-        "name": "NamimnoRC FLASH 2400 OLED TX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "NamimnoRC_FLASH_2400_OLED_TX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "NamimnoRC_FLASH_2400_OLED_TX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-flash2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "NamimnoRC FLASH 2.4 GHz",
-        "name": "NamimnoRC FLASH 2400 RX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "NamimnoRC_FLASH_2400_RX_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "NamimnoRC_FLASH_2400_RX_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-flash2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "NamimnoRC FLASH 2.4 GHz",
-        "name": "NamimnoRC FLASH 2400 ESP RX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "NamimnoRC_FLASH_2400_ESP_RX_via_UART"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "NamimnoRC_FLASH_2400_ESP_RX_via_BetaflightPassthrough"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "NamimnoRC_FLASH_2400_ESP_RX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "USE_DIVERSITY",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "RCVR_UART_BAUD",
-            "RCVR_INVERT_TX"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-flash2400/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "NamimnoRC FLASH 2.4 GHz",
+    "name": "NamimnoRC FLASH 2400 TX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "NamimnoRC_FLASH_2400_TX_via_STLINK"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "NamimnoRC_FLASH_2400_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-flash2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "NamimnoRC FLASH 2.4 GHz",
+    "name": "NamimnoRC FLASH 2400 OLED TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "NamimnoRC_FLASH_2400_OLED_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "NamimnoRC_FLASH_2400_OLED_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-flash2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "NamimnoRC FLASH 2.4 GHz",
+    "name": "NamimnoRC FLASH 2400 RX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "NamimnoRC_FLASH_2400_RX_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "NamimnoRC_FLASH_2400_RX_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-flash2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "NamimnoRC FLASH 2.4 GHz",
+    "name": "NamimnoRC FLASH 2400 ESP RX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "NamimnoRC_FLASH_2400_ESP_RX_via_UART"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "NamimnoRC_FLASH_2400_ESP_RX_via_BetaflightPassthrough"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "NamimnoRC_FLASH_2400_ESP_RX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "USE_DIVERSITY",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "RCVR_UART_BAUD",
+      "RCVR_INVERT_TX"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-flash2400/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/namimnorc-2400.json
+++ b/devices/namimnorc-2400.json
@@ -1,136 +1,131 @@
-[
-  {
-    "category": "NamimnoRC FLASH 2.4 GHz",
-    "name": "NamimnoRC FLASH 2400 TX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "NamimnoRC_FLASH_2400_TX_via_STLINK"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "NamimnoRC_FLASH_2400_TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-flash2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "NamimnoRC FLASH 2.4 GHz",
-    "name": "NamimnoRC FLASH 2400 OLED TX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "NamimnoRC_FLASH_2400_OLED_TX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "NamimnoRC_FLASH_2400_OLED_TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-flash2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "NamimnoRC FLASH 2.4 GHz",
-    "name": "NamimnoRC FLASH 2400 RX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "NamimnoRC_FLASH_2400_RX_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "NamimnoRC_FLASH_2400_RX_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-flash2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "NamimnoRC FLASH 2.4 GHz",
-    "name": "NamimnoRC FLASH 2400 ESP RX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "NamimnoRC_FLASH_2400_ESP_RX_via_UART"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "NamimnoRC_FLASH_2400_ESP_RX_via_BetaflightPassthrough"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "NamimnoRC_FLASH_2400_ESP_RX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "USE_DIVERSITY",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "RCVR_UART_BAUD",
-      "RCVR_INVERT_TX"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-flash2400/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "NamimnoRC FLASH 2.4 GHz",
+        "name": "NamimnoRC FLASH 2400 TX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "NamimnoRC_FLASH_2400_TX_via_STLINK"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "NamimnoRC_FLASH_2400_TX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-flash2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "NamimnoRC FLASH 2.4 GHz",
+        "name": "NamimnoRC FLASH 2400 OLED TX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "NamimnoRC_FLASH_2400_OLED_TX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "NamimnoRC_FLASH_2400_OLED_TX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-flash2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "NamimnoRC FLASH 2.4 GHz",
+        "name": "NamimnoRC FLASH 2400 RX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "NamimnoRC_FLASH_2400_RX_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "NamimnoRC_FLASH_2400_RX_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-flash2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "NamimnoRC FLASH 2.4 GHz",
+        "name": "NamimnoRC FLASH 2400 ESP RX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "NamimnoRC_FLASH_2400_ESP_RX_via_UART"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "NamimnoRC_FLASH_2400_ESP_RX_via_BetaflightPassthrough"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "NamimnoRC_FLASH_2400_ESP_RX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "USE_DIVERSITY",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "RCVR_UART_BAUD",
+            "RCVR_INVERT_TX"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-flash2400/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]

--- a/devices/namimnorc-900.json
+++ b/devices/namimnorc-900.json
@@ -1,132 +1,137 @@
-[{
-        "category": "NamimnoRC VOYAGER 900 MHz",
-        "name": "NamimnoRC VOYAGER 900 TX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "NamimnoRC_VOYAGER_900_TX_via_STLINK"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "NamimnoRC_VOYAGER_900_TX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-voyager900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "NamimnoRC VOYAGER 900 MHz",
-        "name": "NamimnoRC VOYAGER 900 OLED TX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "NamimnoRC_VOYAGER_900_OLED_TX_via_UART"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "NamimnoRC_VOYAGER_900_OLED_TX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "BLE_HID_JOYSTICK",
-            "USE_DYNAMIC_POWER",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-voyager900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "NamimnoRC VOYAGER 900 MHz",
-        "name": "NamimnoRC VOYAGER 900 RX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "NamimnoRC_VOYAGER_900_RX_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "NamimnoRC_VOYAGER_900_RX_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-voyager900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "NamimnoRC VOYAGER 900 MHz",
-        "name": "NamimnoRC VOYAGER 900 ESP RX",
-        "targets": [{
-                "flashingMethod": "UART",
-                "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_UART"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_BetaflightPassthrough"
-            },
-            {
-                "flashingMethod": "WIFI",
-                "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_WIFI"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_AU_915",
-            "REGULATORY_DOMAIN_EU_868",
-            "REGULATORY_DOMAIN_FCC_915",
-            "REGULATORY_DOMAIN_IN_866",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "ARM_CHANNEL",
-            "LOCK_ON_FIRST_CONNECTION",
-            "AUTO_WIFI_ON_BOOT",
-            "AUTO_WIFI_ON_INTERVAL",
-            "HOME_WIFI_SSID",
-            "HOME_WIFI_PASSWORD",
-            "RCVR_UART_BAUD",
-            "RCVR_INVERT_TX"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-voyager900/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "NamimnoRC VOYAGER 900 MHz",
+    "name": "NamimnoRC VOYAGER 900 TX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "NamimnoRC_VOYAGER_900_TX_via_STLINK"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "NamimnoRC_VOYAGER_900_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-voyager900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "NamimnoRC VOYAGER 900 MHz",
+    "name": "NamimnoRC VOYAGER 900 OLED TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "NamimnoRC_VOYAGER_900_OLED_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "NamimnoRC_VOYAGER_900_OLED_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-voyager900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "NamimnoRC VOYAGER 900 MHz",
+    "name": "NamimnoRC VOYAGER 900 RX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "NamimnoRC_VOYAGER_900_RX_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "NamimnoRC_VOYAGER_900_RX_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-voyager900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "NamimnoRC VOYAGER 900 MHz",
+    "name": "NamimnoRC VOYAGER 900 ESP RX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_UART"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_BetaflightPassthrough"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "RCVR_UART_BAUD",
+      "RCVR_INVERT_TX"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-voyager900/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/namimnorc-900.json
+++ b/devices/namimnorc-900.json
@@ -1,137 +1,132 @@
-[
-  {
-    "category": "NamimnoRC VOYAGER 900 MHz",
-    "name": "NamimnoRC VOYAGER 900 TX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "NamimnoRC_VOYAGER_900_TX_via_STLINK"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "NamimnoRC_VOYAGER_900_TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-voyager900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "NamimnoRC VOYAGER 900 MHz",
-    "name": "NamimnoRC VOYAGER 900 OLED TX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "NamimnoRC_VOYAGER_900_OLED_TX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "NamimnoRC_VOYAGER_900_OLED_TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-voyager900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "NamimnoRC VOYAGER 900 MHz",
-    "name": "NamimnoRC VOYAGER 900 RX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "NamimnoRC_VOYAGER_900_RX_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "NamimnoRC_VOYAGER_900_RX_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-voyager900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "NamimnoRC VOYAGER 900 MHz",
-    "name": "NamimnoRC VOYAGER 900 ESP RX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_UART"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_BetaflightPassthrough"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_AU_915",
-      "REGULATORY_DOMAIN_EU_868",
-      "REGULATORY_DOMAIN_FCC_915",
-      "REGULATORY_DOMAIN_IN_866",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "AUTO_WIFI_ON_BOOT",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "RCVR_UART_BAUD",
-      "RCVR_INVERT_TX"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-voyager900/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "NamimnoRC VOYAGER 900 MHz",
+        "name": "NamimnoRC VOYAGER 900 TX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "NamimnoRC_VOYAGER_900_TX_via_STLINK"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "NamimnoRC_VOYAGER_900_TX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-voyager900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "NamimnoRC VOYAGER 900 MHz",
+        "name": "NamimnoRC VOYAGER 900 OLED TX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "NamimnoRC_VOYAGER_900_OLED_TX_via_UART"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "NamimnoRC_VOYAGER_900_OLED_TX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "BLE_HID_JOYSTICK",
+            "USE_DYNAMIC_POWER",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-voyager900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "NamimnoRC VOYAGER 900 MHz",
+        "name": "NamimnoRC VOYAGER 900 RX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "NamimnoRC_VOYAGER_900_RX_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "NamimnoRC_VOYAGER_900_RX_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-voyager900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "NamimnoRC VOYAGER 900 MHz",
+        "name": "NamimnoRC VOYAGER 900 ESP RX",
+        "targets": [{
+                "flashingMethod": "UART",
+                "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_UART"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_BetaflightPassthrough"
+            },
+            {
+                "flashingMethod": "WIFI",
+                "name": "NamimnoRC_VOYAGER_900_ESP_RX_via_WIFI"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_AU_915",
+            "REGULATORY_DOMAIN_EU_868",
+            "REGULATORY_DOMAIN_FCC_915",
+            "REGULATORY_DOMAIN_IN_866",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "ARM_CHANNEL",
+            "LOCK_ON_FIRST_CONNECTION",
+            "AUTO_WIFI_ON_BOOT",
+            "AUTO_WIFI_ON_INTERVAL",
+            "HOME_WIFI_SSID",
+            "HOME_WIFI_PASSWORD",
+            "RCVR_UART_BAUD",
+            "RCVR_INVERT_TX"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-voyager900/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]

--- a/devices/siyi-2400.json
+++ b/devices/siyi-2400.json
@@ -1,88 +1,92 @@
-[{
-        "category": "SIYI 2.4 GHz",
-        "name": "FM30 TX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "FM30_TX_via_STLINK"
-            },
-            {
-                "flashingMethod": "DFU",
-                "name": "FM30_TX_via_DFU"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "USE_DYNAMIC_POWER"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-siyifm30/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "SIYI 2.4 GHz",
-        "name": "FM30 RX MINI",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "FM30_RX_MINI_via_STLINK"
-            },
-            {
-                "flashingMethod": "BetaflightPassthrough",
-                "name": "FM30_RX_MINI_via_BetaflightPassthrough"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "LOCK_ON_FIRST_CONNECTION",
-            "USE_500HZ",
-            "USE_DIVERSITY",
-            "RCVR_UART_BAUD"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-siyiFRmini/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    },
-    {
-        "category": "SIYI 2.4 GHz",
-        "name": "FM30 RX MINI AS TX",
-        "targets": [{
-                "flashingMethod": "STLink",
-                "name": "FM30_RX_MINI_AS_TX_via_STLINK"
-            },
-            {
-                "flashingMethod": "UART",
-                "name": "FM30_RX_MINI_AS_TX_via_UART"
-            }
-        ],
-        "userDefines": [
-            "REGULATORY_DOMAIN_ISM_2400",
-            "REGULATORY_DOMAIN_EU_CE_2400",
-            "BINDING_PHRASE",
-            "HYBRID_SWITCHES_8",
-            "ENABLE_TELEMETRY",
-            "TLM_REPORT_INTERVAL_MS",
-            "NO_SYNC_ON_ARM",
-            "ARM_CHANNEL",
-            "FEATURE_OPENTX_SYNC",
-            "USE_500HZ",
-            "UART_INVERTED",
-            "USE_DYNAMIC_POWER"
-        ],
-        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-siyiFRmini/",
-        "deviceType": "ExpressLRS",
-        "aliases": []
-    }
+[
+  {
+    "category": "SIYI 2.4 GHz",
+    "name": "FM30 TX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "FM30_TX_via_STLINK"
+      },
+      {
+        "flashingMethod": "DFU",
+        "name": "FM30_TX_via_DFU"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "USE_DYNAMIC_POWER"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-siyifm30/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "SIYI 2.4 GHz",
+    "name": "FM30 RX MINI",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "FM30_RX_MINI_via_STLINK"
+      },
+      {
+        "flashingMethod": "BetaflightPassthrough",
+        "name": "FM30_RX_MINI_via_BetaflightPassthrough"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "LOCK_ON_FIRST_CONNECTION",
+      "USE_500HZ",
+      "USE_DIVERSITY",
+      "RCVR_UART_BAUD"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-siyiFRmini/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "SIYI 2.4 GHz",
+    "name": "FM30 RX MINI AS TX",
+    "targets": [
+      {
+        "flashingMethod": "STLink",
+        "name": "FM30_RX_MINI_AS_TX_via_STLINK"
+      },
+      {
+        "flashingMethod": "UART",
+        "name": "FM30_RX_MINI_AS_TX_via_UART"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "USE_DYNAMIC_POWER"
+    ],
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-siyiFRmini/",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
 ]

--- a/devices/siyi-2400.json
+++ b/devices/siyi-2400.json
@@ -1,92 +1,88 @@
-[
-  {
-    "category": "SIYI 2.4 GHz",
-    "name": "FM30 TX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "FM30_TX_via_STLINK"
-      },
-      {
-        "flashingMethod": "DFU",
-        "name": "FM30_TX_via_DFU"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "USE_DYNAMIC_POWER"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/tx-siyifm30/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "SIYI 2.4 GHz",
-    "name": "FM30 RX MINI",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "FM30_RX_MINI_via_STLINK"
-      },
-      {
-        "flashingMethod": "BetaflightPassthrough",
-        "name": "FM30_RX_MINI_via_BetaflightPassthrough"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "LOCK_ON_FIRST_CONNECTION",
-      "USE_500HZ",
-      "USE_DIVERSITY",
-      "RCVR_UART_BAUD"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-siyiFRmini/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "SIYI 2.4 GHz",
-    "name": "FM30 RX MINI AS TX",
-    "targets": [
-      {
-        "flashingMethod": "STLink",
-        "name": "FM30_RX_MINI_AS_TX_via_STLINK"
-      },
-      {
-        "flashingMethod": "UART",
-        "name": "FM30_RX_MINI_AS_TX_via_UART"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "USE_DYNAMIC_POWER"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/rx-siyiFRmini/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+[{
+        "category": "SIYI 2.4 GHz",
+        "name": "FM30 TX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "FM30_TX_via_STLINK"
+            },
+            {
+                "flashingMethod": "DFU",
+                "name": "FM30_TX_via_DFU"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "USE_DYNAMIC_POWER"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-siyifm30/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "SIYI 2.4 GHz",
+        "name": "FM30 RX MINI",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "FM30_RX_MINI_via_STLINK"
+            },
+            {
+                "flashingMethod": "BetaflightPassthrough",
+                "name": "FM30_RX_MINI_via_BetaflightPassthrough"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "LOCK_ON_FIRST_CONNECTION",
+            "USE_500HZ",
+            "USE_DIVERSITY",
+            "RCVR_UART_BAUD"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-siyiFRmini/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    },
+    {
+        "category": "SIYI 2.4 GHz",
+        "name": "FM30 RX MINI AS TX",
+        "targets": [{
+                "flashingMethod": "STLink",
+                "name": "FM30_RX_MINI_AS_TX_via_STLINK"
+            },
+            {
+                "flashingMethod": "UART",
+                "name": "FM30_RX_MINI_AS_TX_via_UART"
+            }
+        ],
+        "userDefines": [
+            "REGULATORY_DOMAIN_ISM_2400",
+            "REGULATORY_DOMAIN_EU_CE_2400",
+            "BINDING_PHRASE",
+            "HYBRID_SWITCHES_8",
+            "ENABLE_TELEMETRY",
+            "TLM_REPORT_INTERVAL_MS",
+            "NO_SYNC_ON_ARM",
+            "ARM_CHANNEL",
+            "FEATURE_OPENTX_SYNC",
+            "USE_500HZ",
+            "UART_INVERTED",
+            "USE_DYNAMIC_POWER"
+        ],
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-siyiFRmini/",
+        "deviceType": "ExpressLRS",
+        "aliases": []
+    }
 ]


### PR DESCRIPTION
Added new expresslrs.org URLs, when selecting various flash methods of some tx/rx hardware.
/trasmitters/ path added where missing in tx wiki URL
/receivers/ path added where missing in rx wiki URL