### PR TITLE
Add warning about unverified hardware

### DIFF
--- a/devices/betafpv-2400.json
+++ b/devices/betafpv-2400.json
@@ -39,7 +39,8 @@
         "category": "HiYOUNGER 2.4 GHz",
         "name": "HiYOUNGER TX2G4 2400 TX",
         "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER TX2G4"
+        "abbreviatedName": "HiYOUNGER TX2G4",
+        "verifiedHardware": false
       }
     ]
   },

--- a/devices/betafpv-900.json
+++ b/devices/betafpv-900.json
@@ -40,7 +40,8 @@
         "category": "HiYOUNGER 900 MHz",
         "name": "HiYOUNGER 900 TX",
         "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER 900 TX"
+        "abbreviatedName": "HiYOUNGER 900 TX",
+        "verifiedHardware": false
       }
     ]
   },
@@ -123,7 +124,8 @@
         "category": "HiYOUNGER 900 MHz",
         "name": "HiYOUNGER 900 RX",
         "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER 900 RX"
+        "abbreviatedName": "HiYOUNGER 900 RX",
+        "verifiedHardware": false
       }
     ]
   }

--- a/devices/diy-2400.json
+++ b/devices/diy-2400.json
@@ -187,49 +187,57 @@
         "category": "Flywoo 2.4 GHz",
         "name": "Flywoo EL24E 2400 RX",
         "wikiUrl": "",
-        "abbreviatedName": "Flywoo EL24E"
+        "abbreviatedName": "Flywoo EL24E",
+        "verifiedHardware": false
       },
       {
         "category": "Flywoo 2.4 GHz",
         "name": "Flywoo EL24P 2400 RX",
         "wikiUrl": "",
-        "abbreviatedName": "Flywoo EL24P"
+        "abbreviatedName": "Flywoo EL24P",
+        "verifiedHardware": false
       },
       {
         "category": "HiYOUNGER 2.4 GHz",
         "name": "HiYOUNGER SP24S 2400 RX",
         "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER SP24S"
+        "abbreviatedName": "HiYOUNGER SP24S",
+        "verifiedHardware": false
       },
       {
         "category": "HiYOUNGER 2.4 GHz",
         "name": "HiYOUNGER EP24S 2400 RX",
         "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER EP24S"
+        "abbreviatedName": "HiYOUNGER EP24S",
+        "verifiedHardware": false
       },
       {
         "category": "HiYOUNGER 2.4 GHz",
         "name": "HiYOUNGER RX24T 2400 RX",
         "wikiUrl": "",
-        "abbreviatedName": "HiYOUNGER RX24T"
+        "abbreviatedName": "HiYOUNGER RX24T",
+        "verifiedHardware": false
       },
       {
         "category": "JHEMCU 2.4 GHz",
         "name": "JHEMCU SP24S 2400 RX",
         "wikiUrl": "",
-        "abbreviatedName": "JHEMCU SP24S"
+        "abbreviatedName": "JHEMCU SP24S",
+        "verifiedHardware": false
       },
       {
         "category": "JHEMCU 2.4 GHz",
         "name": "JHEMCU EP24S 2400 RX",
         "wikiUrl": "",
-        "abbreviatedName": "JHEMCU EP24S"
+        "abbreviatedName": "JHEMCU EP24S",
+        "verifiedHardware": false
       },
       {
         "category": "JHEMCU 2.4 GHz",
         "name": "JHEMCU RX24T 2400 RX",
         "wikiUrl": "",
-        "abbreviatedName": "JHEMCU RX24T"
+        "abbreviatedName": "JHEMCU RX24T",
+        "verifiedHardware": false
       },
       {
         "category": "Jumper 2.4 GHz",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -813,6 +813,22 @@
             "deprecationReason": null
           },
           {
+            "name": "verifiedHardware",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "parent",
             "description": null,
             "args": [],
@@ -839,6 +855,16 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Boolean",
+        "description": "The `Boolean` scalar type represents `true` or `false`.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -1579,16 +1605,6 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Boolean",
-        "description": "The `Boolean` scalar type represents `true` or `false`.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/src/api/src/models/Device.ts
+++ b/src/api/src/models/Device.ts
@@ -26,6 +26,9 @@ export default class Device {
   @Field()
   deviceType: DeviceType;
 
+  @Field()
+  verifiedHardware: boolean;
+
   @Field({ nullable: true })
   parent?: string | null;
 
@@ -39,6 +42,7 @@ export default class Device {
     targets: Target[],
     userDefines: UserDefineKey[],
     deviceType: DeviceType,
+    verifiedHardware: boolean,
     wikiUrl?: string,
     parent?: string | null,
     abbreviatedName?: string | null
@@ -50,6 +54,7 @@ export default class Device {
     this.userDefines = userDefines;
     this.wikiUrl = wikiUrl;
     this.deviceType = deviceType;
+    this.verifiedHardware = verifiedHardware;
     this.parent = parent;
     this.abbreviatedName = abbreviatedName;
   }

--- a/src/api/src/services/Device/index.ts
+++ b/src/api/src/services/Device/index.ts
@@ -113,6 +113,7 @@ export default class DeviceService implements IDevices {
           deviceType,
           parent: null,
           abbreviatedName: value.abbreviatedName,
+          verifiedHardware: value.verifiedHardware ?? true,
         };
 
         devices.push(device);
@@ -124,6 +125,7 @@ export default class DeviceService implements IDevices {
               category: any;
               wikiUrl: any;
               abbreviatedName?: any;
+              verifiedHardware?: boolean;
             }) => {
               devices.push({
                 id: alias.name,
@@ -141,6 +143,7 @@ export default class DeviceService implements IDevices {
                 deviceType: device.deviceType,
                 parent: device.id,
                 abbreviatedName: alias.abbreviatedName,
+                verifiedHardware: alias.verifiedHardware ?? true,
               });
             }
           );

--- a/src/ui/components/DeviceTargetForm/index.tsx
+++ b/src/ui/components/DeviceTargetForm/index.tsx
@@ -5,7 +5,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { Box } from '@mui/material';
+import { Alert, AlertTitle, Box } from '@mui/material';
 import Omnibox from '../Omnibox';
 import {
   Device,
@@ -19,6 +19,9 @@ import FlashingMethodOptions, {
 const styles = {
   root: {
     marginY: 2,
+  },
+  dangerZone: {
+    marginBottom: 4,
   },
 };
 
@@ -156,6 +159,14 @@ const DeviceTargetForm: FunctionComponent<FirmwareVersionCardProps> = ({
 
   return (
     <>
+      {currentDevice && !currentDevice.verifiedHardware && (
+        <Alert severity="warning" sx={styles.dangerZone}>
+          <AlertTitle>UNVERIFIED HARDWARE</AlertTitle>
+          The manufacturer of this hardware has not provided samples to the
+          developers for evaluation and verification, contact them for support
+          or proceed at your own risk. Not all features may work.
+        </Alert>
+      )}
       <Box sx={styles.root}>
         <Omnibox
           title="Device category"

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -97,6 +97,7 @@ export type Device = {
   readonly userDefines: ReadonlyArray<UserDefineKey>;
   readonly wikiUrl?: Maybe<Scalars['String']>;
   readonly deviceType: DeviceType;
+  readonly verifiedHardware: Scalars['Boolean'];
   readonly parent?: Maybe<Scalars['String']>;
   readonly abbreviatedName?: Maybe<Scalars['String']>;
 };
@@ -462,6 +463,7 @@ export type AvailableFirmwareTargetsQuery = {
       | 'deviceType'
       | 'parent'
       | 'abbreviatedName'
+      | 'verifiedHardware'
     > & {
         readonly targets: ReadonlyArray<
           { readonly __typename?: 'Target' } & Pick<
@@ -842,6 +844,7 @@ export const AvailableFirmwareTargetsDocument = gql`
       deviceType
       parent
       abbreviatedName
+      verifiedHardware
     }
   }
 `;

--- a/src/ui/gql/queries/availableFirmwareTargets.graphql
+++ b/src/ui/gql/queries/availableFirmwareTargets.graphql
@@ -29,5 +29,6 @@ query availableFirmwareTargets(
     deviceType
     parent
     abbreviatedName
+    verifiedHardware
   }
 }


### PR DESCRIPTION
Add a warning that shows when a user selects a device that has not be verified to work correctly by the ExpressLRS developers.