### PR TITLE
Add HappyModel EP82 as alias of ESP01F

### DIFF
--- a/devices/rapidfire-backpack.json
+++ b/devices/rapidfire-backpack.json
@@ -19,7 +19,13 @@
     ],
     "wikiUrl": "https://www.expresslrs.org/{version}/hardware/backpack/backpack-vrx-setup/#rapidfire-backpack-connection",
     "deviceType": "Backpack",
-    "aliases": []
+    "aliases": [
+      {
+        "name": "HappyModel EP82 VRX Backpack",
+        "category": "VRX",
+        "wikiUrl": "https://www.expresslrs.org/{version}/hardware/backpack/backpack-vrx-setup/#rapidfire-backpack-connection"
+      }
+    ]
   },
   {
     "category": "VRX",


### PR DESCRIPTION
Branched from ExpressLRS/Backpack#49. Creates an alias of the ESP01F VRX module for the HappyModel EP82. Lack of a definition for this model is a source of continuing confusion for users trying to flash a VRX backpack. It makes some logical sense to use the "HappyModel EP" target for an EP82, but in fact, those pins will result in the module not booting.

Not yet tested - I'll be able to do that here in a bit.