### PR TITLE
Adds via ETXPassthrough to Jumper T-Pro

### DIFF
--- a/devices/jumper-2400.json
+++ b/devices/jumper-2400.json
@@ -41,6 +41,10 @@
       {
         "flashingMethod": "WIFI",
         "name": "Jumper_AION_2400_T-Pro_TX_via_WIFI"
+      },
+      {
+        "flashingMethod": "EdgeTxPassthrough",
+        "name": "Jumper_AION_2400_T-Pro_TX_via_ETX"
       }
     ],
     "userDefines": [


### PR DESCRIPTION
This PR adds via ETXPassthrough flashing option for the Jumper TPro internal ExpressLRS module.

This is inline with the main Repo PR #1383