### PR TITLE
Launch PlatformIO in a shell

### DIFF
--- a/src/api/src/library/FirmwareDownloader/index.ts
+++ b/src/api/src/library/FirmwareDownloader/index.ts
@@ -84,6 +84,13 @@ export class GitFirmwareDownloader implements IFirmwareDownloader {
     return path.join(this.baseDirectory, path.basename(repository));
   }
 
+  getSourceDirectory(directory: string, srcFolder: string): string {
+    if (srcFolder === '/') {
+      return directory;
+    }
+    return path.join(directory, srcFolder);
+  }
+
   getSimpleGit(repository: string) {
     const options: SimpleGitOptions = {
       baseDir: this.getRepoDirectory(repository),
@@ -148,7 +155,7 @@ export class GitFirmwareDownloader implements IFirmwareDownloader {
     const git = this.getSimpleGit(directory);
     await git.checkout(tagName);
     return {
-      path: path.join(directory, srcFolder),
+      path: this.getSourceDirectory(directory, srcFolder),
     };
   }
 
@@ -162,7 +169,7 @@ export class GitFirmwareDownloader implements IFirmwareDownloader {
     const git = this.getSimpleGit(directory);
     await git.checkout(`origin/${branch}`);
     return {
-      path: path.join(directory, srcFolder),
+      path: this.getSourceDirectory(directory, srcFolder),
     };
   }
 
@@ -176,7 +183,7 @@ export class GitFirmwareDownloader implements IFirmwareDownloader {
     const git = this.getSimpleGit(directory);
     await git.checkout(commit);
     return {
-      path: path.join(directory, srcFolder),
+      path: this.getSourceDirectory(directory, srcFolder),
     };
   }
 }

--- a/src/api/src/library/Platformio/index.ts
+++ b/src/api/src/library/Platformio/index.ts
@@ -208,9 +208,11 @@ export default class Platformio {
     onUpdate: OnOutputFunc = NoOpFunc
   ) {
     return this.runPIOCommand(
-      ['run', '--project-dir', projectDir, '--environment', environment],
+      ['run', '--project-dir', `"${projectDir}"`, '--environment', environment],
       {
         env: this.env,
+        shell: true,
+        windowsVerbatimArguments: true,
       },
       onUpdate
     );
@@ -225,7 +227,7 @@ export default class Platformio {
     const params = [
       'run',
       '--project-dir',
-      projectDir,
+      `"${projectDir}"`,
       '--environment',
       environment,
       '--target',
@@ -239,6 +241,8 @@ export default class Platformio {
       params,
       {
         env: this.env,
+        shell: true,
+        windowsVerbatimArguments: true,
       },
       onUpdate
     );


### PR DESCRIPTION
With the upgrade of the bundled python on Windows to 3.11.0a4, when spawning a PlatformIO process, the output is coming through the wrong output pipes and eventually filling up the buffer.  If PlatformIO is launched in a shell, the output of the process correctly comes through the expected stdout and stderr pipes and can be read as normal.