### PR TITLE
Git based loading of target and user defines fixes

### DIFF
--- a/src/api/src/library/Mutex/index.ts
+++ b/src/api/src/library/Mutex/index.ts
@@ -12,6 +12,23 @@ export default class Mutex {
     this.locked = true;
   }
 
+  // naive spin lock style try lock with timeout
+  // not efficient, do not use if protected area is heavily accessed
+  async tryLockWithTimeout(timeout: number) {
+    const curDateMs = new Date().getTime();
+    while (new Date().getTime() - curDateMs < timeout) {
+      if (this.isLocked()) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      if (!this.isLocked()) {
+        this.tryLock();
+        return;
+      }
+    }
+    throw new Error('Mutex timed out waiting for lock');
+  }
+
   isLocked(): boolean {
     return this.locked;
   }

--- a/src/api/src/services/TargetsLoader/GitTargets.ts
+++ b/src/api/src/services/TargetsLoader/GitTargets.ts
@@ -1,4 +1,5 @@
 import { Service } from 'typedi';
+import path from 'path';
 import FirmwareSource from '../../models/enum/FirmwareSource';
 import TargetArgs from '../../graphql/args/Target';
 import { LoggerService } from '../../logger';
@@ -10,9 +11,12 @@ import {
   findGitExecutable,
   GitFirmwareDownloader,
 } from '../../library/FirmwareDownloader';
+import Mutex from '../../library/Mutex';
 
 @Service()
 export default class GitTargetsService extends TargetsLoader {
+  mutex: Mutex;
+
   constructor(
     private logger: LoggerService,
     private deviceService: DeviceService,
@@ -20,90 +24,99 @@ export default class GitTargetsService extends TargetsLoader {
     private targetStoragePath: string
   ) {
     super();
+    this.mutex = new Mutex();
   }
 
   async loadTargetsList(
     args: TargetArgs,
     gitRepository: GitRepository
   ): Promise<Device[]> {
-    let gitPath = '';
+    await this.mutex.tryLockWithTimeout(60000);
+
     try {
-      gitPath = await findGitExecutable(this.PATH);
-    } catch (e) {
-      this.logger?.error('failed to find git', undefined, {
-        PATH: this.PATH,
-        err: e,
+      let gitPath = '';
+      try {
+        gitPath = await findGitExecutable(this.PATH);
+      } catch (e) {
+        this.logger?.error('failed to find git', undefined, {
+          PATH: this.PATH,
+          err: e,
+        });
+        throw e;
+      }
+      this.logger?.log('git path', {
+        gitPath,
       });
-      throw e;
-    }
-    this.logger?.log('git path', {
-      gitPath,
-    });
 
-    const firmwareDownload = new GitFirmwareDownloader(
-      {
-        baseDirectory: this.targetStoragePath,
-        gitBinaryLocation: gitPath,
-      },
-      this.logger
-    );
+      const firmwareDownload = new GitFirmwareDownloader(
+        {
+          baseDirectory: this.targetStoragePath,
+          gitBinaryLocation: gitPath,
+        },
+        this.logger
+      );
 
-    let availableTargets: string[] = [];
-    switch (args.source) {
-      case FirmwareSource.GitBranch:
-        const branchResult = await firmwareDownload.checkoutBranch(
-          gitRepository.url,
-          `${gitRepository.srcFolder}/targets`,
-          args.gitBranch
-        );
-        availableTargets = await loadTargetsFromDirectory(branchResult.path);
-        break;
-      case FirmwareSource.GitCommit:
-        const commitResult = await firmwareDownload.checkoutCommit(
-          gitRepository.url,
-          `${gitRepository.srcFolder}/targets`,
-          args.gitCommit
-        );
-        availableTargets = await loadTargetsFromDirectory(commitResult.path);
-        break;
-      case FirmwareSource.GitTag:
-        const tagResult = await firmwareDownload.checkoutTag(
-          gitRepository.url,
-          `${gitRepository.srcFolder}/targets`,
-          args.gitTag
-        );
-        availableTargets = await loadTargetsFromDirectory(tagResult.path);
-        break;
-      case FirmwareSource.GitPullRequest:
-        if (args.gitPullRequest === null) {
-          throw new Error('empty GitPullRequest head commit hash');
-        }
-        const prResult = await firmwareDownload.checkoutCommit(
-          gitRepository.url,
-          `${gitRepository.srcFolder}/targets`,
-          args.gitPullRequest.headCommitHash
-        );
-        availableTargets = await loadTargetsFromDirectory(prResult.path);
-        break;
-      case FirmwareSource.Local:
-        availableTargets = await loadTargetsFromDirectory(
-          `${args.localPath}/targets`
-        );
-        break;
-      default:
-        throw new Error(
-          `unsupported firmware source for the targets service: ${args.source}`
-        );
+      let availableTargets: string[] = [];
+      const srcFolder =
+        gitRepository.srcFolder === '/' ? '' : `${gitRepository.srcFolder}/`;
+      switch (args.source) {
+        case FirmwareSource.GitBranch:
+          const branchResult = await firmwareDownload.checkoutBranch(
+            gitRepository.url,
+            `${srcFolder}targets`,
+            args.gitBranch
+          );
+          availableTargets = await loadTargetsFromDirectory(branchResult.path);
+          break;
+        case FirmwareSource.GitCommit:
+          const commitResult = await firmwareDownload.checkoutCommit(
+            gitRepository.url,
+            `${srcFolder}targets`,
+            args.gitCommit
+          );
+          availableTargets = await loadTargetsFromDirectory(commitResult.path);
+          break;
+        case FirmwareSource.GitTag:
+          const tagResult = await firmwareDownload.checkoutTag(
+            gitRepository.url,
+            `${srcFolder}targets`,
+            args.gitTag
+          );
+          availableTargets = await loadTargetsFromDirectory(tagResult.path);
+          break;
+        case FirmwareSource.GitPullRequest:
+          if (args.gitPullRequest === null) {
+            throw new Error('empty GitPullRequest head commit hash');
+          }
+          const prResult = await firmwareDownload.checkoutCommit(
+            gitRepository.url,
+            `${srcFolder}targets`,
+            args.gitPullRequest.headCommitHash
+          );
+          availableTargets = await loadTargetsFromDirectory(prResult.path);
+          break;
+        case FirmwareSource.Local:
+          availableTargets = await loadTargetsFromDirectory(
+            path.join(args.localPath, 'targets')
+          );
+          break;
+        default:
+          throw new Error(
+            `unsupported firmware source for the targets service: ${args.source}`
+          );
+      }
+      const devices = this.deviceService.getDevices();
+      return devices
+        .map((value) => {
+          const device = { ...value };
+          device.targets = value.targets.filter((item) =>
+            availableTargets.find((target) => target === item.name)
+          );
+          return device;
+        })
+        .filter((item) => item.targets.length > 0);
+    } finally {
+      this.mutex.unlock();
     }
-    const devices = this.deviceService.getDevices();
-    return devices
-      .map((value) => {
-        const device = { ...value };
-        device.targets = value.targets.filter((item) =>
-          availableTargets.find((target) => target === item.name)
-        );
-        return device;
-      })
-      .filter((item) => item.targets.length > 0);
   }
 }

--- a/src/api/src/services/UserDefinesLoader/GitUserDefinesLoader.ts
+++ b/src/api/src/services/UserDefinesLoader/GitUserDefinesLoader.ts
@@ -1,5 +1,6 @@
 import { Service } from 'typedi';
 import fs from 'fs';
+import path from 'path';
 import UserDefineKey from '../../library/FirmwareBuilder/Enum/UserDefineKey';
 import FirmwareSource from '../../models/enum/FirmwareSource';
 import { LoggerService } from '../../logger';
@@ -9,94 +10,109 @@ import {
   findGitExecutable,
   GitFirmwareDownloader,
 } from '../../library/FirmwareDownloader';
+import Mutex from '../../library/Mutex';
 
 @Service()
 export default class GitUserDefinesLoader implements UserDefinesLoader {
+  mutex: Mutex;
+
   constructor(
     private logger: LoggerService,
     private PATH: string,
     private userDefinesStoragePath: string
-  ) {}
+  ) {
+    this.mutex = new Mutex();
+  }
 
   async loadUserDefinesTxt(
     userDefineFilters: UserDefineFilters,
     gitRepository: GitRepository
   ): Promise<UserDefineKey[]> {
-    this.logger?.log('git based loadUserDefinesTxt', {
-      userDefineFilters,
-    });
-
-    let gitPath = '';
+    await this.mutex.tryLockWithTimeout(60000);
     try {
-      gitPath = await findGitExecutable(this.PATH);
-    } catch (e) {
-      this.logger?.error('failed to find git', undefined, {
-        PATH: this.PATH,
-        err: e,
+      this.logger?.log('git based loadUserDefinesTxt', {
+        userDefineFilters,
       });
-      throw e;
-    }
-    this.logger?.log('git path', {
-      gitPath,
-    });
 
-    const firmwareDownload = new GitFirmwareDownloader(
-      {
-        baseDirectory: this.userDefinesStoragePath,
-        gitBinaryLocation: gitPath,
-      },
-      this.logger
-    );
+      let gitPath = '';
+      try {
+        gitPath = await findGitExecutable(this.PATH);
+      } catch (e) {
+        this.logger?.error('failed to find git', undefined, {
+          PATH: this.PATH,
+          err: e,
+        });
+        throw e;
+      }
+      this.logger?.log('git path', {
+        gitPath,
+      });
 
-    switch (userDefineFilters.source) {
-      case FirmwareSource.GitBranch:
-        const branchResult = await firmwareDownload.checkoutBranch(
-          gitRepository.url,
-          `${gitRepository.srcFolder}/user_defines.txt`,
-          userDefineFilters.gitBranch
-        );
-        const branchData = await fs.promises.readFile(
-          branchResult.path,
-          'utf8'
-        );
-        return extractCompatibleKeys(branchData);
-      case FirmwareSource.GitCommit:
-        const commitResult = await firmwareDownload.checkoutCommit(
-          gitRepository.url,
-          `${gitRepository.srcFolder}/user_defines.txt`,
-          userDefineFilters.gitCommit
-        );
-        const commitData = await fs.promises.readFile(
-          commitResult.path,
-          'utf8'
-        );
-        return extractCompatibleKeys(commitData);
-      case FirmwareSource.GitTag:
-        const tagResult = await firmwareDownload.checkoutTag(
-          gitRepository.url,
-          `${gitRepository.srcFolder}/user_defines.txt`,
-          userDefineFilters.gitTag
-        );
-        const tagData = await fs.promises.readFile(tagResult.path, 'utf8');
-        return extractCompatibleKeys(tagData);
-      case FirmwareSource.Local:
-        const data = await fs.promises.readFile(
-          `${userDefineFilters.localPath}/user_defines.txt`,
-          'utf8'
-        );
-        return extractCompatibleKeys(data);
-      case FirmwareSource.GitPullRequest:
-        const prResult = await firmwareDownload.checkoutCommit(
-          gitRepository.url,
-          `${gitRepository.srcFolder}/user_defines.txt`,
-          userDefineFilters.gitCommit
-        );
-        const prData = await fs.promises.readFile(prResult.path, 'utf8');
-        return extractCompatibleKeys(prData);
-      default:
-        throw new Error(
-          `unsupported firmware source: ${userDefineFilters.source}`
-        );
+      const firmwareDownload = new GitFirmwareDownloader(
+        {
+          baseDirectory: this.userDefinesStoragePath,
+          gitBinaryLocation: gitPath,
+        },
+        this.logger
+      );
+      const srcFolder =
+        gitRepository.srcFolder === '/' ? '' : `${gitRepository.srcFolder}/`;
+
+      switch (userDefineFilters.source) {
+        case FirmwareSource.GitBranch:
+          const branchResult = await firmwareDownload.checkoutBranch(
+            gitRepository.url,
+            `${srcFolder}user_defines.txt`,
+            userDefineFilters.gitBranch
+          );
+          const branchData = await fs.promises.readFile(
+            branchResult.path,
+            'utf8'
+          );
+          return extractCompatibleKeys(branchData);
+        case FirmwareSource.GitCommit:
+          const commitResult = await firmwareDownload.checkoutCommit(
+            gitRepository.url,
+            `${srcFolder}user_defines.txt`,
+            userDefineFilters.gitCommit
+          );
+          const commitData = await fs.promises.readFile(
+            commitResult.path,
+            'utf8'
+          );
+          return extractCompatibleKeys(commitData);
+        case FirmwareSource.GitTag:
+          const tagResult = await firmwareDownload.checkoutTag(
+            gitRepository.url,
+            `${srcFolder}user_defines.txt`,
+            userDefineFilters.gitTag
+          );
+          const tagData = await fs.promises.readFile(tagResult.path, 'utf8');
+          return extractCompatibleKeys(tagData);
+        case FirmwareSource.Local:
+          const data = await fs.promises.readFile(
+            path.join(userDefineFilters.localPath, 'user_defines.txt'),
+            'utf8'
+          );
+          return extractCompatibleKeys(data);
+        case FirmwareSource.GitPullRequest:
+          if (userDefineFilters.gitPullRequest === null) {
+            throw new Error('empty GitPullRequest head commit hash');
+          }
+          const prResult = await firmwareDownload.checkoutCommit(
+            gitRepository.url,
+            `${srcFolder}user_defines.txt`,
+            userDefineFilters.gitPullRequest.headCommitHash
+          );
+          const prData = await fs.promises.readFile(prResult.path, 'utf8');
+          return extractCompatibleKeys(prData);
+        default:
+          throw new Error(
+            `unsupported firmware source: ${userDefineFilters.source}`
+          );
+      }
+    } finally {
+      this.mutex.unlock();
     }
   }
 }


### PR DESCRIPTION
- Handle situation where src folder is at the root of the repo, like the Backpack repo.
- Add locking around access to the local git repos for targets and user defines to prevent multiple processes accessing/modifying the files at the same time. Closes #260 
- Fix Git Pull Request source in the user defines loader