### PR TITLE
Handle space in Platform IO executable path when using shell

### DIFF
--- a/src/api/src/library/Platformio/index.ts
+++ b/src/api/src/library/Platformio/index.ts
@@ -194,8 +194,15 @@ export default class Platformio {
       });
     }
 
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    let { platformio_exe } = state;
+    // if using shell, surround exe in quotes in case path has a space in it
+    if (options.shell) {
+      platformio_exe = `"${platformio_exe}"`;
+    }
+
     return new Commander().runCommand(
-      state.platformio_exe,
+      platformio_exe,
       [...args],
       options,
       onOutput


### PR DESCRIPTION
When spawning Platform IO using a shell, wrap the fully qualified path name in quotes so that spaces in the path do not cause an issue. 

Closes #275 