### PR TITLE
Add Force Upload Support

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -2329,6 +2329,12 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "TargetMismatch",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -2452,6 +2458,18 @@
           },
           {
             "name": "BuildAndFlash",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ForceFlash",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CheckTarget",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -2467,12 +2467,6 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "CheckTarget",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "possibleTypes": null

--- a/src/api/src/library/FirmwareBuilder/index.ts
+++ b/src/api/src/library/FirmwareBuilder/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import Platformio from '../Platformio';
 import { CommandResult, NoOpFunc, OnOutputFunc } from '../Commander';
 import UserDefineKey from './Enum/UserDefineKey';
+import BuildJobType from '../../models/enum/BuildJobType';
 
 interface UserDefinesCompatiblityResult {
   compatible: boolean;
@@ -75,9 +76,16 @@ export default class FirmwareBuilder {
     userDefines: string,
     firmwarePath: string,
     serialPort: string | undefined,
-    onOutput: OnOutputFunc = NoOpFunc
+    onOutput: OnOutputFunc = NoOpFunc,
+    buildJobType: BuildJobType
   ): Promise<CommandResult> {
     await this.storeUserDefines(firmwarePath, userDefines);
-    return this.platformio.flash(firmwarePath, target, serialPort, onOutput);
+    return this.platformio.flash(
+      firmwarePath,
+      target,
+      serialPort,
+      onOutput,
+      buildJobType
+    );
   }
 }

--- a/src/api/src/library/FirmwareBuilder/index.ts
+++ b/src/api/src/library/FirmwareBuilder/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import Platformio from '../Platformio';
 import { CommandResult, NoOpFunc, OnOutputFunc } from '../Commander';
 import UserDefineKey from './Enum/UserDefineKey';
-import BuildJobType from '../../models/enum/BuildJobType';
+import UploadType from '../Platformio/Enum/UploadType';
 
 interface UserDefinesCompatiblityResult {
   compatible: boolean;
@@ -77,7 +77,7 @@ export default class FirmwareBuilder {
     firmwarePath: string,
     serialPort: string | undefined,
     onOutput: OnOutputFunc = NoOpFunc,
-    buildJobType: BuildJobType
+    uploadType: UploadType
   ): Promise<CommandResult> {
     await this.storeUserDefines(firmwarePath, userDefines);
     return this.platformio.flash(
@@ -85,7 +85,7 @@ export default class FirmwareBuilder {
       target,
       serialPort,
       onOutput,
-      buildJobType
+      uploadType
     );
   }
 }

--- a/src/api/src/library/Platformio/Enum/UploadType.ts
+++ b/src/api/src/library/Platformio/Enum/UploadType.ts
@@ -1,0 +1,7 @@
+enum UploadType {
+  Normal = 'upload',
+  Force = 'uploadforce',
+  Confirm = 'uploadconfirm',
+}
+
+export default UploadType;

--- a/src/api/src/library/Platformio/Enum/UploadType.ts
+++ b/src/api/src/library/Platformio/Enum/UploadType.ts
@@ -1,7 +1,6 @@
 enum UploadType {
   Normal = 'upload',
   Force = 'uploadforce',
-  Confirm = 'uploadconfirm',
 }
 
 export default UploadType;

--- a/src/api/src/library/Platformio/index.ts
+++ b/src/api/src/library/Platformio/index.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import child_process from 'child_process';
 import Commander, { CommandResult, NoOpFunc, OnOutputFunc } from '../Commander';
 import { LoggerService } from '../../logger';
+import BuildJobType from '../../models/enum/BuildJobType';
 
 interface PlatformioCoreState {
   core_version: string;
@@ -229,8 +230,16 @@ export default class Platformio {
     projectDir: string,
     environment: string,
     serialPort: string | undefined,
-    onUpdate: OnOutputFunc = NoOpFunc
+    onUpdate: OnOutputFunc = NoOpFunc,
+    buildJobType: BuildJobType
   ) {
+    let pioTarget = 'upload';
+    if (buildJobType === BuildJobType.ForceFlash) {
+      pioTarget = 'uploadforce';
+    } else if (buildJobType === BuildJobType.CheckTarget) {
+      pioTarget = 'uploadconfirm';
+    }
+
     const params = [
       'run',
       '--project-dir',
@@ -238,7 +247,7 @@ export default class Platformio {
       '--environment',
       environment,
       '--target',
-      'upload',
+      pioTarget,
     ];
     if (serialPort !== undefined && serialPort !== null) {
       params.push('--upload-port');

--- a/src/api/src/library/Platformio/index.ts
+++ b/src/api/src/library/Platformio/index.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import child_process from 'child_process';
 import Commander, { CommandResult, NoOpFunc, OnOutputFunc } from '../Commander';
 import { LoggerService } from '../../logger';
-import BuildJobType from '../../models/enum/BuildJobType';
+import UploadType from './Enum/UploadType';
 
 interface PlatformioCoreState {
   core_version: string;
@@ -231,15 +231,8 @@ export default class Platformio {
     environment: string,
     serialPort: string | undefined,
     onUpdate: OnOutputFunc = NoOpFunc,
-    buildJobType: BuildJobType
+    uploadType: UploadType
   ) {
-    let pioTarget = 'upload';
-    if (buildJobType === BuildJobType.ForceFlash) {
-      pioTarget = 'uploadforce';
-    } else if (buildJobType === BuildJobType.CheckTarget) {
-      pioTarget = 'uploadconfirm';
-    }
-
     const params = [
       'run',
       '--project-dir',
@@ -247,7 +240,7 @@ export default class Platformio {
       '--environment',
       environment,
       '--target',
-      pioTarget,
+      uploadType,
     ];
     if (serialPort !== undefined && serialPort !== null) {
       params.push('--upload-port');

--- a/src/api/src/models/enum/BuildFirmwareErrorType.ts
+++ b/src/api/src/models/enum/BuildFirmwareErrorType.ts
@@ -7,6 +7,7 @@ enum BuildFirmwareErrorType {
   BuildError = 'BuildError',
   FlashError = 'FlashError',
   GenericError = 'GenericError',
+  TargetMismatch = 'TargetMismatch',
 }
 
 registerEnumType(BuildFirmwareErrorType, {

--- a/src/api/src/models/enum/BuildJobType.ts
+++ b/src/api/src/models/enum/BuildJobType.ts
@@ -4,7 +4,6 @@ enum BuildJobType {
   Build = 'Build',
   BuildAndFlash = 'BuildAndFlash',
   ForceFlash = 'ForceFlash',
-  CheckTarget = 'CheckTarget',
 }
 
 registerEnumType(BuildJobType, {

--- a/src/api/src/models/enum/BuildJobType.ts
+++ b/src/api/src/models/enum/BuildJobType.ts
@@ -3,6 +3,8 @@ import { registerEnumType } from 'type-graphql';
 enum BuildJobType {
   Build = 'Build',
   BuildAndFlash = 'BuildAndFlash',
+  ForceFlash = 'ForceFlash',
+  CheckTarget = 'CheckTarget',
 }
 
 registerEnumType(BuildJobType, {

--- a/src/api/src/services/Firmware/index.ts
+++ b/src/api/src/services/Firmware/index.ts
@@ -25,6 +25,7 @@ import FirmwareBuilder from '../../library/FirmwareBuilder';
 import { LoggerService } from '../../logger';
 import UserDefineKey from '../../library/FirmwareBuilder/Enum/UserDefineKey';
 import PullRequest from '../../models/PullRequest';
+import UploadType from '../../library/Platformio/Enum/UploadType';
 
 interface FirmwareVersionData {
   source: FirmwareSource;
@@ -462,6 +463,19 @@ export default class FirmwareService {
           BuildProgressNotificationType.Info,
           BuildFirmwareStep.FLASHING_FIRMWARE
         );
+
+        let uploadType: UploadType;
+        switch (params.type) {
+          case BuildJobType.BuildAndFlash:
+            uploadType = UploadType.Normal;
+            break;
+          case BuildJobType.ForceFlash:
+            uploadType = UploadType.Force;
+            break;
+          default:
+            throw new Error(`Unknown build job type ${params.type}`);
+        }
+
         const flashResult = await this.builder.flash(
           params.target,
           userDefines,
@@ -470,7 +484,7 @@ export default class FirmwareService {
           (output) => {
             this.updateLogs(output);
           },
-          params.type
+          uploadType
         );
         if (!flashResult.success) {
           this.logger?.error('flash error', undefined, {

--- a/src/ui/components/BuildProgressBar/index.tsx
+++ b/src/ui/components/BuildProgressBar/index.tsx
@@ -46,20 +46,6 @@ const BuildProgressBar: FunctionComponent<BuildProgressBarProps> = memo(
           }
           break;
         case BuildJobType.BuildAndFlash:
-          switch (notification.step) {
-            case BuildFirmwareStep.VERIFYING_BUILD_SYSTEM:
-              return 5;
-            case BuildFirmwareStep.DOWNLOADING_FIRMWARE:
-              return 15;
-            case BuildFirmwareStep.BUILDING_USER_DEFINES:
-              return 28;
-            case BuildFirmwareStep.BUILDING_FIRMWARE:
-              return 56;
-            case BuildFirmwareStep.FLASHING_FIRMWARE:
-              return 89;
-            default:
-          }
-          break;
         case BuildJobType.ForceFlash:
           switch (notification.step) {
             case BuildFirmwareStep.VERIFYING_BUILD_SYSTEM:

--- a/src/ui/components/BuildProgressBar/index.tsx
+++ b/src/ui/components/BuildProgressBar/index.tsx
@@ -60,6 +60,21 @@ const BuildProgressBar: FunctionComponent<BuildProgressBarProps> = memo(
             default:
           }
           break;
+        case BuildJobType.ForceFlash:
+          switch (notification.step) {
+            case BuildFirmwareStep.VERIFYING_BUILD_SYSTEM:
+              return 5;
+            case BuildFirmwareStep.DOWNLOADING_FIRMWARE:
+              return 15;
+            case BuildFirmwareStep.BUILDING_USER_DEFINES:
+              return 28;
+            case BuildFirmwareStep.BUILDING_FIRMWARE:
+              return 56;
+            case BuildFirmwareStep.FLASHING_FIRMWARE:
+              return 89;
+            default:
+          }
+          break;
         default:
           throw new Error(`unhandled job type: ${jobType}`);
       }

--- a/src/ui/components/BuildResponse/index.tsx
+++ b/src/ui/components/BuildResponse/index.tsx
@@ -37,6 +37,8 @@ const BuildResponse: FunctionComponent<BuildResponseProps> = memo(
           return 'Build error';
         case BuildFirmwareErrorType.FlashError:
           return 'Flash error';
+        case BuildFirmwareErrorType.TargetMismatch:
+          return 'The target you are trying to flash does not match the devices current target, if you are sure you want to do this, click Force Flash below';
         default:
           return '';
       }

--- a/src/ui/components/SplitButton/index.tsx
+++ b/src/ui/components/SplitButton/index.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import ButtonGroup, { ButtonGroupProps } from '@mui/material/ButtonGroup';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
+import Grow from '@mui/material/Grow';
+import Paper from '@mui/material/Paper';
+import Popper from '@mui/material/Popper';
+import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
+import { FunctionComponent, useState } from 'react';
+import { uniqueId } from 'lodash';
+
+export interface Option {
+  label: string;
+  value: string;
+}
+
+interface SplitButtonProps extends ButtonGroupProps {
+  options: Option[];
+  onButtonClick: (value: string | null) => void;
+}
+
+const SplitButton: FunctionComponent<SplitButtonProps> = ({
+  options,
+  onButtonClick,
+  ...props
+}) => {
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef<HTMLDivElement | null>(null);
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const [splitButtonMenuId] = useState(() => uniqueId('split-button-menu-'));
+
+  const handleClick = () => {
+    onButtonClick(options[selectedIndex].value);
+  };
+
+  const handleMenuItemClick = (event: any, index: number) => {
+    setSelectedIndex(index);
+    setOpen(false);
+  };
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+
+  const handleClose = (event: any) => {
+    if (
+      anchorRef.current &&
+      event.target &&
+      anchorRef.current.contains(event.target)
+    ) {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <ButtonGroup {...props} ref={anchorRef}>
+        <Button onClick={handleClick}>{options[selectedIndex].label}</Button>
+        <Button
+          size="small"
+          aria-controls={open ? splitButtonMenuId : undefined}
+          aria-expanded={open ? 'true' : undefined}
+          aria-label="select button"
+          aria-haspopup="menu"
+          onClick={handleToggle}
+        >
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
+      <Popper
+        open={open}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        transition
+        disablePortal
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === 'bottom' ? 'center top' : 'center bottom',
+            }}
+          >
+            <Paper>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList id={splitButtonMenuId}>
+                  {options.map((option, index) => (
+                    <MenuItem
+                      key={option.value}
+                      selected={index === selectedIndex}
+                      onClick={(event) => handleMenuItemClick(event, index)}
+                    >
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </>
+  );
+};
+
+export default SplitButton;

--- a/src/ui/components/SplitButton/index.tsx
+++ b/src/ui/components/SplitButton/index.tsx
@@ -77,6 +77,7 @@ const SplitButton: FunctionComponent<SplitButtonProps> = ({
         role={undefined}
         transition
         disablePortal
+        style={{ zIndex: 2 }}
       >
         {({ TransitionProps, placement }) => (
           <Grow

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -311,7 +311,6 @@ export enum BuildJobType {
   Build = 'Build',
   BuildAndFlash = 'BuildAndFlash',
   ForceFlash = 'ForceFlash',
-  CheckTarget = 'CheckTarget',
 }
 
 export type FirmwareVersionDataInput = {

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -294,6 +294,7 @@ export enum BuildFirmwareErrorType {
   BuildError = 'BuildError',
   FlashError = 'FlashError',
   GenericError = 'GenericError',
+  TargetMismatch = 'TargetMismatch',
 }
 
 export type BuildFlashFirmwareInput = {
@@ -309,6 +310,8 @@ export type BuildFlashFirmwareInput = {
 export enum BuildJobType {
   Build = 'Build',
   BuildAndFlash = 'BuildAndFlash',
+  ForceFlash = 'ForceFlash',
+  CheckTarget = 'CheckTarget',
 }
 
 export type FirmwareVersionDataInput = {

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -56,6 +56,7 @@ import {
   UserDefineKey,
   UserDefineKind,
   TargetDeviceOptionsQuery,
+  BuildFirmwareErrorType,
 } from '../../gql/generated/types';
 import Loader from '../../components/Loader';
 import BuildResponse from '../../components/BuildResponse';
@@ -77,6 +78,7 @@ import ShowTimeoutAlerts from '../../components/ShowTimeoutAlerts';
 import useAppState from '../../hooks/useAppState';
 import AppStatus from '../../models/enum/AppStatus';
 import MainLayout from '../../layouts/MainLayout';
+import SplitButton from '../../components/SplitButton';
 
 const styles = {
   button: {
@@ -661,6 +663,7 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
 
   const onBuild = () => sendJob(BuildJobType.Build);
   const onBuildAndFlash = () => sendJob(BuildJobType.BuildAndFlash);
+  const onForceFlash = () => sendJob(BuildJobType.ForceFlash);
 
   const deviceOptionsRef = useRef<HTMLDivElement | null>(null);
 
@@ -913,14 +916,28 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
                   Build
                 </Button>
                 {deviceTarget?.flashingMethod !== FlashingMethod.Radio && (
-                  <Button
+                  <SplitButton
                     sx={styles.button}
                     size="large"
                     variant="contained"
-                    onClick={onBuildAndFlash}
-                  >
-                    Build & Flash
-                  </Button>
+                    options={[
+                      {
+                        label: 'Build & Flash',
+                        value: BuildJobType.BuildAndFlash,
+                      },
+                      {
+                        label: 'Force Flash',
+                        value: BuildJobType.ForceFlash,
+                      },
+                    ]}
+                    onButtonClick={(value: string | null) => {
+                      if (value === BuildJobType.BuildAndFlash) {
+                        onBuildAndFlash();
+                      } else if (value === BuildJobType.ForceFlash) {
+                        onForceFlash();
+                      }
+                    }}
+                  />
                 )}
               </div>
             </CardContent>
@@ -1053,15 +1070,26 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
                     sx={styles.button}
                     size="large"
                     variant="contained"
-                    onClick={
-                      currentJobType === BuildJobType.Build
-                        ? onBuild
-                        : onBuildAndFlash
-                    }
+                    onClick={() => {
+                      sendJob(currentJobType);
+                    }}
                   >
                     Retry
                   </Button>
                 )}
+
+                {!response?.buildFlashFirmware.success &&
+                  response?.buildFlashFirmware.errorType ===
+                    BuildFirmwareErrorType.TargetMismatch && (
+                    <Button
+                      sx={styles.button}
+                      size="large"
+                      variant="contained"
+                      onClick={onForceFlash}
+                    >
+                      Force Flash
+                    </Button>
+                  )}
 
                 {response?.buildFlashFirmware.success && luaDownloadButton()}
               </CardContent>


### PR DESCRIPTION
- Add support for a new build type that allows force flashing a device when the new firmware target does not match the devices existing firmware target
- Change the current "Build & Flash" button to a split button with 2 options, "Build & Flash" and "Force Flash" ![image](https://user-images.githubusercontent.com/38869875/154565640-b06b7330-2dd3-4cbc-b992-d347c3ad5a89.png)
- When "Build & Flash" fails with a target mismatch error, show the "Force Flash" button. ![image](https://user-images.githubusercontent.com/38869875/154565903-786c4aa4-2143-4cf8-83c0-e260429c0efb.png)

Closes #250 

