### PR TITLE
Use windows-2019 for the windows build environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'windows-latest', 'macos-latest' ]
+        os: [ 'ubuntu-18.04', 'windows-2019', 'macos-latest' ]
     steps:
       - name: Setup apt dependencies
         if: matrix.os == 'ubuntu-18.04'
@@ -40,7 +40,7 @@ jobs:
           yarn install --prefer-offline --network-timeout 180000
 
       - name: Publish Windows releases
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         shell: powershell
         env:
           # These values are used for auto updates signing


### PR DESCRIPTION
GitHub moved the windows-latest VM Environment to a Windows Server 2022 image which is causing issues with the build process, change to specifically use windows-2019.