### PR TITLE
Warn about unplugging power to soon when flashing via WIFI

### DIFF
--- a/src/ui/components/ShowAfterTimeout/index.tsx
+++ b/src/ui/components/ShowAfterTimeout/index.tsx
@@ -1,0 +1,37 @@
+import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
+
+interface ShowAfterTimeoutProps {
+  timeout: number;
+  active: boolean;
+}
+
+const ShowAfterTimeout: FunctionComponent<ShowAfterTimeoutProps> = ({
+  timeout,
+  active,
+  ...props
+}) => {
+  const [visible, setVisible] = useState<boolean>(false);
+  const activeRef = useRef(active);
+  activeRef.current = active;
+  const timeoutRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (activeRef.current) {
+      timeoutRef.current = window.setTimeout(() => {
+        setVisible(true);
+      }, timeout);
+    } else {
+      setVisible(false);
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+    }
+    return () => {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [active, timeout]);
+  return <>{visible && props.children}</>;
+};
+
+export default ShowAfterTimeout;

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -75,6 +75,7 @@ import WifiDeviceSelect from '../../components/WifiDeviceSelect';
 import WifiDeviceList from '../../components/WifiDeviceList';
 import GitRepository from '../../models/GitRepository';
 import ShowTimeoutAlerts from '../../components/ShowTimeoutAlerts';
+import ShowAfterTimeout from '../../components/ShowAfterTimeout';
 import useAppState from '../../hooks/useAppState';
 import AppStatus from '../../models/enum/AppStatus';
 import MainLayout from '../../layouts/MainLayout';
@@ -1024,9 +1025,39 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
               <CardTitle icon={<SettingsIcon />} title="Result" />
               <Divider />
               <CardContent>
-                <Box sx={styles.buildNotification}>
-                  <BuildResponse response={response?.buildFlashFirmware} />
-                </Box>
+                {response?.buildFlashFirmware?.success &&
+                  currentJobType === BuildJobType.BuildAndFlash &&
+                  deviceTarget?.flashingMethod === FlashingMethod.WIFI && (
+                    <>
+                      <Alert sx={styles.buildNotification} severity="warning">
+                        <AlertTitle>Warning</AlertTitle>
+                        Please wait for LED to resume blinking before
+                        disconnecting power
+                      </Alert>
+                    </>
+                  )}
+                <ShowAfterTimeout
+                  timeout={
+                    response?.buildFlashFirmware?.success &&
+                    currentJobType === BuildJobType.BuildAndFlash &&
+                    deviceTarget?.flashingMethod === FlashingMethod.WIFI
+                      ? 15000
+                      : 1000
+                  }
+                  active={!buildInProgress}
+                >
+                  <Box sx={styles.buildNotification}>
+                    <BuildResponse response={response?.buildFlashFirmware} />
+                  </Box>
+                  {response?.buildFlashFirmware?.success && hasLuaScript && (
+                    <>
+                      <Alert sx={styles.buildNotification} severity="info">
+                        <AlertTitle>Update Lua Script</AlertTitle>
+                        Make sure to update the Lua script on your radio
+                      </Alert>
+                    </>
+                  )}
+                </ShowAfterTimeout>
                 {response?.buildFlashFirmware?.success &&
                   currentJobType === BuildJobType.Build && (
                     <>
@@ -1038,14 +1069,6 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
                       </Alert>
                     </>
                   )}
-                {response?.buildFlashFirmware?.success && hasLuaScript && (
-                  <>
-                    <Alert sx={styles.buildNotification} severity="info">
-                      <AlertTitle>Update Lua Script</AlertTitle>
-                      Make sure to update the Lua script on your radio
-                    </Alert>
-                  </>
-                )}
               </CardContent>
               <Divider />
             </>


### PR DESCRIPTION
There seems to be a common problem of individuals unplugging their device too soon after a WIFI flash before the device has fully rebooted, which can cause the device to be soft bricked and stuck in a boot loop.  When flashing via the webpage, there is a delay in showing the success message to alleviate this issue, but this does not exist in the configurator.

After a successful WIFI flash, show a warning about unplugging the power to soon and delay the success message for 15 seconds to allow for the device to fully reboot.

![image](https://user-images.githubusercontent.com/38869875/157740334-5c1145fd-68bf-474b-bb38-52954026e7ab.png)
