### PR TITLE
Add copy logs button

### DIFF
--- a/src/ui/components/CardTitle/index.tsx
+++ b/src/ui/components/CardTitle/index.tsx
@@ -11,7 +11,7 @@ const CardTitle: FunctionComponent<CardTitleProps> = memo(({ icon, title }) => {
     <CardContent>
       <Grid container spacing={1} alignItems="center">
         <Grid item>{icon}</Grid>
-        <Grid item>
+        <Grid item flexGrow={1}>
           <Typography variant="h6">{title}</Typography>
         </Grid>
       </Grid>

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -19,11 +19,12 @@ import {
   DialogContentText,
   DialogTitle,
   Divider,
+  IconButton,
   Tooltip,
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { ipcRenderer } from 'electron';
-import { NetworkWifi } from '@mui/icons-material';
+import { ContentCopy, NetworkWifi } from '@mui/icons-material';
 import FirmwareVersionForm from '../../components/FirmwareVersionForm';
 import DeviceTargetForm from '../../components/DeviceTargetForm';
 import DeviceOptionsForm, {
@@ -1003,7 +1004,24 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
 
           {logs.length > 0 && (
             <>
-              <CardTitle icon={<SettingsIcon />} title="Logs" />
+              <CardTitle
+                icon={<SettingsIcon />}
+                title={
+                  <Box display="flex" justifyContent="space-between">
+                    <Box>Logs</Box>
+                    <Box>
+                      <IconButton
+                        aria-label="Copy the logs"
+                        onClick={async () => {
+                          await navigator.clipboard.writeText(logs);
+                        }}
+                      >
+                        <ContentCopy />
+                      </IconButton>
+                    </Box>
+                  </Box>
+                }
+              />
               <Divider />
               <CardContent>
                 <Box sx={styles.longBuildDurationWarning}>


### PR DESCRIPTION
Add a button to the Logs card title that allows easy copying of the build log.

![image](https://user-images.githubusercontent.com/38869875/157951017-d1f6dc5d-3013-446d-90ac-3fe4fb4d477d.png)
