### PR TITLE
Generic build error message

### DIFF
--- a/src/ui/components/BuildResponse/index.tsx
+++ b/src/ui/components/BuildResponse/index.tsx
@@ -4,21 +4,25 @@ import { SxProps, Theme } from '@mui/system';
 import {
   BuildFirmwareErrorType,
   BuildFlashFirmwareResult,
+  FirmwareVersionDataInput,
 } from '../../gql/generated/types';
+import DocumentationLink from '../DocumentationLink';
 
 const styles: SxProps<Theme> = {
   errorMessage: {
-    whiteSpace: 'pre-wrap',
-    fontFamily: 'monospace',
+    a: {
+      color: 'white',
+    },
   },
 };
 
 interface BuildResponseProps {
   response: BuildFlashFirmwareResult | undefined;
+  firmwareVersionData: FirmwareVersionDataInput | null;
 }
 
 const BuildResponse: FunctionComponent<BuildResponseProps> = memo(
-  ({ response }) => {
+  ({ response, firmwareVersionData }) => {
     // TODO: translations
     const toTitle = (errorType: BuildFirmwareErrorType | undefined): string => {
       if (errorType === null || errorType === undefined) {
@@ -55,7 +59,42 @@ const BuildResponse: FunctionComponent<BuildResponseProps> = memo(
                 response?.errorType ?? BuildFirmwareErrorType.GenericError
               )}
             </AlertTitle>
-            {response?.message}
+            <p>
+              An error has occured, see the above log for the exact error
+              message. If you have not already done so, visit{' '}
+              <DocumentationLink
+                firmwareVersion={firmwareVersionData}
+                url="https://www.expresslrs.org/{version}/"
+              >
+                Expresslrs.org
+              </DocumentationLink>{' '}
+              and read the{' '}
+              <DocumentationLink
+                firmwareVersion={firmwareVersionData}
+                url="https://www.expresslrs.org/{version}/quick-start/getting-started/"
+              >
+                Flashing Guide
+              </DocumentationLink>{' '}
+              for your particular device as well as the{' '}
+              <DocumentationLink
+                firmwareVersion={firmwareVersionData}
+                url="https://www.expresslrs.org/{version}/quick-start/troubleshooting/#flashingupdating"
+              >
+                Troubleshooting Guide
+              </DocumentationLink>
+              . If you are still having issues after reviewing the
+              documentation, please copy the build logs above to an online paste
+              site and post in the #help-and-support channel on the{' '}
+              <DocumentationLink
+                firmwareVersion={firmwareVersionData}
+                url="https://discord.gg/dS6ReFY"
+              >
+                ExpressLRS Discord
+              </DocumentationLink>{' '}
+              with a link to the logs and other relevant information like your
+              device, which flashing method you were using, and what steps you
+              have already taken to resolve the issue.
+            </p>
           </Alert>
         )}
       </>

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -1065,7 +1065,10 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
                   active={!buildInProgress}
                 >
                   <Box sx={styles.buildNotification}>
-                    <BuildResponse response={response?.buildFlashFirmware} />
+                    <BuildResponse
+                      response={response?.buildFlashFirmware}
+                      firmwareVersionData={firmwareVersionData}
+                    />
                   </Box>
                   {response?.buildFlashFirmware?.success && hasLuaScript && (
                     <>


### PR DESCRIPTION
Including the stderr output of the build job in the build error alert is not very useful since it can contain extraneous data not relevant to the issue itself while also not containing enough contextual information to understand the actual cause of the issue.  Instead of including the stderr output, include a generic message directing the user to the documentation and to the help-and-support channel on discord.

![image](https://user-images.githubusercontent.com/38869875/158513172-45b4f7fc-5b83-45f1-90b3-c23539373e63.png)
