### PR TITLE
Disable Linebreak Style Rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,8 @@ module.exports = {
       'error',
       { ignoreFunctionalComponents: true },
     ],
+    // No need to enforce linebreak styles since "* text=auto" in .gitattributes will ensure LF is committed to the repo
+    'linebreak-style': 'off',
   },
   parserOptions: {
     ecmaVersion: 2020,


### PR DESCRIPTION
No need to enforce linebreak styles since "* text=auto" in .gitattributes will ensure LF is committed to the repo