### PR TITLE
Add user defines history

### DIFF
--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -132,7 +132,7 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                       label={inputLabel(item.key)}
                     />
                   )}
-                  {item.sensitive && (
+                  {item.sensitive && !item.historyEnabled && (
                     <SensitiveTextField
                       name={item.key}
                       size="small"
@@ -142,23 +142,22 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                       label={inputLabel(item.key)}
                     />
                   )}
-                  {!item.sensitive &&
-                    item.history &&
-                    item.history?.length > 0 &&
-                    item.historyEnabled && (
-                      <Autocomplete
-                        freeSolo
-                        size="small"
-                        options={item.history}
-                        renderInput={(params) => (
-                          <TextField
-                            {...params}
-                            label={inputLabel(item.key)}
-                            onChange={onUserDefineValueChange(item.key)}
-                          />
-                        )}
-                      />
-                    )}
+                  {item.historyEnabled && (
+                    <Autocomplete
+                      freeSolo
+                      fullWidth
+                      size="small"
+                      options={item.history || []}
+                      defaultValue={item.value}
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label={inputLabel(item.key)}
+                          onChange={onUserDefineValueChange(item.key)}
+                        />
+                      )}
+                    />
+                  )}
                 </ListItem>
               </>
             )}

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 import React, { FunctionComponent } from 'react';
 import {
+  Autocomplete,
   Checkbox,
   List,
   ListItem,
@@ -122,7 +123,7 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
             {item.type === UserDefineKind.Text && item.enabled && (
               <>
                 <ListItem sx={styles.complimentaryItem}>
-                  {!item.sensitive && (
+                  {!item.sensitive && !item.historyEnabled && (
                     <TextField
                       size="small"
                       onChange={onUserDefineValueChange(item.key)}
@@ -141,6 +142,23 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                       label={inputLabel(item.key)}
                     />
                   )}
+                  {!item.sensitive &&
+                    item.history &&
+                    item.history?.length > 0 &&
+                    item.historyEnabled && (
+                      <Autocomplete
+                        freeSolo
+                        size="small"
+                        options={item.history}
+                        renderInput={(params) => (
+                          <TextField
+                            {...params}
+                            label={inputLabel(item.key)}
+                            onChange={onUserDefineValueChange(item.key)}
+                          />
+                        )}
+                      />
+                    )}
                 </ListItem>
               </>
             )}

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -120,23 +120,6 @@ export enum FlashingMethod {
   Radio = 'Radio',
 }
 
-export type UserDefine = {
-  readonly __typename?: 'UserDefine';
-  readonly type: UserDefineKind;
-  readonly key: UserDefineKey;
-  readonly enabled: Scalars['Boolean'];
-  readonly sensitive: Scalars['Boolean'];
-  readonly enumValues?: Maybe<ReadonlyArray<Scalars['String']>>;
-  readonly value?: Maybe<Scalars['String']>;
-  readonly optionGroup?: Maybe<UserDefineOptionGroup>;
-};
-
-export enum UserDefineKind {
-  Boolean = 'Boolean',
-  Text = 'Text',
-  Enum = 'Enum',
-}
-
 export enum UserDefineKey {
   BINDING_PHRASE = 'BINDING_PHRASE',
   REGULATORY_DOMAIN_AU_915 = 'REGULATORY_DOMAIN_AU_915',
@@ -180,11 +163,6 @@ export enum UserDefineKey {
   AUTO_WIFI_ON_BOOT = 'AUTO_WIFI_ON_BOOT',
   AUTO_WIFI_ON_INTERVAL = 'AUTO_WIFI_ON_INTERVAL',
   DEVICE_NAME = 'DEVICE_NAME',
-}
-
-export enum UserDefineOptionGroup {
-  RegulatoryDomain900 = 'RegulatoryDomain900',
-  RegulatoryDomain2400 = 'RegulatoryDomain2400',
 }
 
 export enum DeviceType {
@@ -238,7 +216,6 @@ export enum UserDefineOptionGroup {
   RegulatoryDomain900 = 'RegulatoryDomain900',
   RegulatoryDomain2400 = 'RegulatoryDomain2400',
 }
-
 
 export type Release = {
   readonly __typename?: 'Release';

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -201,6 +201,8 @@ export type UserDefine = {
   readonly sensitive: Scalars['Boolean'];
   readonly enumValues?: Maybe<ReadonlyArray<Scalars['String']>>;
   readonly value?: Maybe<Scalars['String']>;
+  readonly history?: Maybe<ReadonlyArray<Scalars['String']>>;
+  readonly historyEnabled?: Maybe<Scalars['Boolean']>;
   readonly optionGroup?: Maybe<UserDefineOptionGroup>;
 };
 

--- a/src/ui/storage/commands/mergeWithDeviceOptionsFromStorage.ts
+++ b/src/ui/storage/commands/mergeWithDeviceOptionsFromStorage.ts
@@ -11,6 +11,10 @@ const mergeWithDeviceOptionsFromStorage = async (
   deviceOptions: DeviceOptions
 ): Promise<DeviceOptions> => {
   const savedBindingPhrase = await storage.getBindingPhrase();
+  const savedBindingPhraseHistory = await storage.getHistory(
+    UserDefineKey.BINDING_PHRASE
+  );
+
   const savedTargetOptions = device
     ? await storage.getDeviceOptions(device)
     : null;
@@ -27,6 +31,8 @@ const mergeWithDeviceOptionsFromStorage = async (
       return {
         ...deviceOption,
         value: savedBindingPhrase,
+        historyEnabled: true,
+        history: savedBindingPhraseHistory,
       };
     }
     if (

--- a/src/ui/storage/commands/updateDeviceOptionsHistory.ts
+++ b/src/ui/storage/commands/updateDeviceOptionsHistory.ts
@@ -8,7 +8,6 @@ const updateDeviceOptionHistory = async (
     await Promise.all(
       deviceOptions.userDefineOptions.map(async (userDefine) => {
         if (
-          userDefine.enabled &&
           userDefine.historyEnabled &&
           userDefine.value &&
           userDefine.value?.length > 0

--- a/src/ui/storage/commands/updateDeviceOptionsHistory.ts
+++ b/src/ui/storage/commands/updateDeviceOptionsHistory.ts
@@ -1,0 +1,23 @@
+import { DeviceOptions, IApplicationStorage } from '../index';
+
+const updateDeviceOptionHistory = async (
+  storage: IApplicationStorage,
+  deviceOptions: DeviceOptions
+): Promise<void> => {
+  if (deviceOptions !== null) {
+    await Promise.all(
+      deviceOptions.userDefineOptions.map(async (userDefine) => {
+        if (
+          userDefine.enabled &&
+          userDefine.historyEnabled &&
+          userDefine.value &&
+          userDefine.value?.length > 0
+        ) {
+          storage.updateHistory(userDefine.key, userDefine.value);
+        }
+      })
+    );
+  }
+};
+
+export default updateDeviceOptionHistory;

--- a/src/ui/storage/index.ts
+++ b/src/ui/storage/index.ts
@@ -26,6 +26,10 @@ export interface IApplicationStorage {
 
   getBindingPhrase(): Promise<string>;
 
+  getHistory(key: string): Promise<string[]>;
+
+  updateHistory(key: string, value: string): Promise<void>;
+
   getFirmwareSource(
     gitRepository: GitRepository
   ): Promise<FirmwareVersionDataInput | null>;
@@ -134,6 +138,29 @@ export default class ApplicationStorage implements IApplicationStorage {
       return '';
     }
     return value;
+  }
+
+  async getHistory(key: string): Promise<string[]> {
+    const value = localStorage.getItem(`${key}_HISTORY`);
+
+    if (value == null) {
+      return [];
+    }
+
+    try {
+      const parsedValue = JSON.parse(value);
+      return parsedValue;
+    } catch {
+      return [];
+    }
+  }
+
+  async updateHistory(key: string, value: string): Promise<void> {
+    const currentHistory = await this.getHistory(key);
+    const newHistory = currentHistory.filter((word: string) => word !== value);
+    newHistory.unshift(value);
+    newHistory.length = 10;
+    localStorage.setItem(`${key}_HISTORY`, JSON.stringify(newHistory));
   }
 
   async getShowPreReleases(defaultValue: boolean): Promise<boolean> {

--- a/src/ui/storage/index.ts
+++ b/src/ui/storage/index.ts
@@ -157,9 +157,11 @@ export default class ApplicationStorage implements IApplicationStorage {
 
   async updateHistory(key: string, value: string): Promise<void> {
     const currentHistory = await this.getHistory(key);
-    const newHistory = currentHistory.filter((word: string) => word !== value);
+    const newHistory = currentHistory.filter(
+      (word: string) => word !== (value || null)
+    );
     newHistory.unshift(value);
-    newHistory.length = 10;
+    newHistory.length = newHistory.length < 10 ? newHistory.length : 10;
     localStorage.setItem(`${key}_HISTORY`, JSON.stringify(newHistory));
   }
 

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -72,6 +72,7 @@ import UserDefinesValidator from './UserDefinesValidator';
 import ApplicationStorage from '../../storage';
 import persistDeviceOptions from '../../storage/commands/persistDeviceOptions';
 import mergeWithDeviceOptionsFromStorage from '../../storage/commands/mergeWithDeviceOptionsFromStorage';
+import updateDeviceOptionsHistory from '../../storage/commands/updateDeviceOptionsHistory';
 import UserDefinesAdvisor from '../../components/UserDefinesAdvisor';
 import SerialDeviceSelect from '../../components/SerialDeviceSelect';
 import WifiDeviceSelect from '../../components/WifiDeviceSelect';
@@ -619,6 +620,9 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
       type: item.type,
     }));
 
+    const storage = new ApplicationStorage();
+    updateDeviceOptionsHistory(storage, deviceOptionsFormData);
+
     if (device?.parent && device?.name) {
       const deviceName = getAbbreviatedDeviceName(device);
       // add the user define for the device name
@@ -652,6 +656,7 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
         },
       },
     });
+
     setViewState(ViewState.Compiling);
     setAppStatus(AppStatus.Busy);
   };


### PR DESCRIPTION
Here is the initial attempt at general user defines history, though right now I only have it activated for binding phrase.

- I added two new properties to user define
    - historyEnabled: bool
    - history: [string]
- When a build is issued, all userDefined for which historyEnabled = true will have the current value added to their history
- Right now I set historyEnabled to true when the userdefines are merged with the stored values but this doesn't seem to happen when the app is launched for the first time so I'll need to look into a better place to do that
- When historyEnabled is true there is an <Autocomplete /> component that will be rendered instead of the normal text input

Outstanding Issues:
- Setting the value of historyEnabled when first launching the app
- toggling between hiding and showing the data in the field for privacy