### PR TITLE
Add ability to override user define default values in device configuration file

### DIFF
--- a/devices/namimnorc-2400.json
+++ b/devices/namimnorc-2400.json
@@ -154,7 +154,7 @@
       "ENABLE_TELEMETRY",
       "LOCK_ON_FIRST_CONNECTION",
       "USE_500HZ",
-      "USE_DIVERSITY",
+      {"key": "USE_DIVERSITY", "enabled": true},
       "AUTO_WIFI_ON_BOOT",
       "AUTO_WIFI_ON_INTERVAL",
       "HOME_WIFI_SSID",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -774,8 +774,8 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "ENUM",
-                    "name": "UserDefineKey",
+                    "kind": "OBJECT",
+                    "name": "UserDefine",
                     "ofType": null
                   }
                 }
@@ -979,6 +979,154 @@
           },
           {
             "name": "Radio",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UserDefine",
+        "description": null,
+        "fields": [
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "UserDefineKind",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "UserDefineKey",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "enabled",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sensitive",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "enumValues",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "optionGroup",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "UserDefineOptionGroup",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "UserDefineKind",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "Boolean",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "Text",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "Enum",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -1251,6 +1399,29 @@
       },
       {
         "kind": "ENUM",
+        "name": "UserDefineOptionGroup",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "RegulatoryDomain900",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RegulatoryDomain2400",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
         "name": "DeviceType",
         "description": null,
         "fields": null,
@@ -1487,177 +1658,6 @@
         "inputFields": null,
         "interfaces": null,
         "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "UserDefine",
-        "description": null,
-        "fields": [
-          {
-            "name": "type",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "UserDefineKind",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "key",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "UserDefineKey",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enabled",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sensitive",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "enumValues",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "value",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "optionGroup",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "UserDefineOptionGroup",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "UserDefineKind",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "Boolean",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "Text",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "Enum",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "UserDefineOptionGroup",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "RegulatoryDomain900",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "RegulatoryDomain2400",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
         "possibleTypes": null
       },
       {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -24,7 +24,6 @@ import SerialMonitorResolver from './src/graphql/resolvers/SerialMonitor.resolve
 import SerialMonitorService from './src/services/SerialMonitor';
 import GitTargetsService from './src/services/TargetsLoader/GitTargets';
 import DeviceService from './src/services/Device';
-import TargetUserDefinesFactory from './src/factories/TargetUserDefinesFactory';
 import MulticastDnsService from './src/services/MulticastDns';
 import MulticastDnsMonitorResolver from './src/graphql/resolvers/MulticastDnsMonitor.resolver';
 import LuaService from './src/services/Lua';
@@ -106,29 +105,22 @@ export default class ApiServer {
 
     Container.set(DeviceService, deviceService);
 
-    const targetUserDefinesFactory = new TargetUserDefinesFactory(
-      deviceService
-    );
-
     if (config.userDefinesLoader === FirmwareParamsLoaderType.Git) {
       Container.set(
         UserDefinesBuilder,
         new UserDefinesBuilder(
-          targetUserDefinesFactory,
           new GitUserDefinesLoader(
             logger,
             config.PATH,
             config.userDefinesStoragePath
-          )
+          ),
+          deviceService
         )
       );
     } else if (config.userDefinesLoader === FirmwareParamsLoaderType.Http) {
       Container.set(
         UserDefinesBuilder,
-        new UserDefinesBuilder(
-          targetUserDefinesFactory,
-          new HttpUserDefinesLoader(logger)
-        )
+        new UserDefinesBuilder(new HttpUserDefinesLoader(logger), deviceService)
       );
     }
 

--- a/src/api/src/factories/TargetUserDefinesFactory.ts
+++ b/src/api/src/factories/TargetUserDefinesFactory.ts
@@ -1,179 +1,135 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-import { Service } from 'typedi';
 import UserDefineKey from '../library/FirmwareBuilder/Enum/UserDefineKey';
 import UserDefineOptionGroup from '../models/enum/UserDefineOptionGroup';
 import UserDefine from '../models/UserDefine';
-import DeviceService from '../services/Device';
 
-@Service()
 export default class TargetUserDefinesFactory {
-  constructor(private deviceService: DeviceService) {}
-
-  build(target: string): UserDefine[] {
-    const device = this.deviceService.getDevices().find((item) => {
-      return item.targets.find((t) => t.name === target);
-    });
-
-    const userDefines = device?.userDefines.map(
-      (userDefine): UserDefine => {
-        switch (userDefine) {
-          // BINDING PHRASE
-          case UserDefineKey.BINDING_PHRASE:
-            return UserDefine.Text(
-              UserDefineKey.BINDING_PHRASE,
-              '',
-              true,
-              true
-            );
-          // Regulatory domains
-          case UserDefineKey.REGULATORY_DOMAIN_AU_915:
-            return UserDefine.Boolean(
-              UserDefineKey.REGULATORY_DOMAIN_AU_915,
-              false,
-              UserDefineOptionGroup.RegulatoryDomain900
-            );
-          case UserDefineKey.REGULATORY_DOMAIN_EU_868:
-            return UserDefine.Boolean(
-              UserDefineKey.REGULATORY_DOMAIN_EU_868,
-              false,
-              UserDefineOptionGroup.RegulatoryDomain900
-            );
-          case UserDefineKey.REGULATORY_DOMAIN_IN_866:
-            return UserDefine.Boolean(
-              UserDefineKey.REGULATORY_DOMAIN_IN_866,
-              false,
-              UserDefineOptionGroup.RegulatoryDomain900
-            );
-          case UserDefineKey.REGULATORY_DOMAIN_AU_433:
-            return UserDefine.Boolean(UserDefineKey.REGULATORY_DOMAIN_AU_433);
-          case UserDefineKey.REGULATORY_DOMAIN_EU_433:
-            return UserDefine.Boolean(UserDefineKey.REGULATORY_DOMAIN_EU_433);
-          case UserDefineKey.REGULATORY_DOMAIN_FCC_915:
-            return UserDefine.Boolean(
-              UserDefineKey.REGULATORY_DOMAIN_FCC_915,
-              false,
-              UserDefineOptionGroup.RegulatoryDomain900
-            );
-          case UserDefineKey.REGULATORY_DOMAIN_ISM_2400:
-            return UserDefine.Boolean(
-              UserDefineKey.REGULATORY_DOMAIN_ISM_2400,
-              true,
-              UserDefineOptionGroup.RegulatoryDomain2400
-            );
-          case UserDefineKey.REGULATORY_DOMAIN_EU_CE_2400:
-            return UserDefine.Boolean(
-              UserDefineKey.REGULATORY_DOMAIN_EU_CE_2400,
-              true,
-              UserDefineOptionGroup.RegulatoryDomain2400
-            );
-          // Hybrid switches
-          case UserDefineKey.HYBRID_SWITCHES_8:
-            return UserDefine.Boolean(UserDefineKey.HYBRID_SWITCHES_8, true);
-          case UserDefineKey.ENABLE_TELEMETRY:
-            return UserDefine.Boolean(UserDefineKey.ENABLE_TELEMETRY);
-          case UserDefineKey.TLM_REPORT_INTERVAL_MS:
-            return UserDefine.Text(
-              UserDefineKey.TLM_REPORT_INTERVAL_MS,
-              '320LU'
-            );
-          // Performance options
-          case UserDefineKey.FAST_SYNC:
-            return UserDefine.Boolean(UserDefineKey.FAST_SYNC);
-          case UserDefineKey.R9M_UNLOCK_HIGHER_POWER:
-            return UserDefine.Boolean(UserDefineKey.R9M_UNLOCK_HIGHER_POWER);
-          case UserDefineKey.UNLOCK_HIGHER_POWER:
-            return UserDefine.Boolean(UserDefineKey.UNLOCK_HIGHER_POWER, true);
-          case UserDefineKey.USE_DIVERSITY:
-            if (target.startsWith('NamimnoRC_FLASH_2400_ESP_RX_PA')) {
-              return UserDefine.Boolean(UserDefineKey.USE_DIVERSITY, true);
-            }
-            return UserDefine.Boolean(UserDefineKey.USE_DIVERSITY);
-          case UserDefineKey.NO_SYNC_ON_ARM:
-            return UserDefine.Boolean(UserDefineKey.NO_SYNC_ON_ARM);
-          case UserDefineKey.ARM_CHANNEL:
-            return UserDefine.Enum(
-              UserDefineKey.ARM_CHANNEL,
-              ['AUX1', 'AUX2', 'AUX3', 'AUX4', 'AUX5', 'AUX6'],
-              'AUX1'
-            );
-          case UserDefineKey.FEATURE_OPENTX_SYNC:
-            return UserDefine.Boolean(UserDefineKey.FEATURE_OPENTX_SYNC, true);
-          case UserDefineKey.FEATURE_OPENTX_SYNC_AUTOTUNE:
-            return UserDefine.Boolean(
-              UserDefineKey.FEATURE_OPENTX_SYNC_AUTOTUNE
-            );
-          case UserDefineKey.LOCK_ON_FIRST_CONNECTION:
-            return UserDefine.Boolean(
-              UserDefineKey.LOCK_ON_FIRST_CONNECTION,
-              true
-            );
-          case UserDefineKey.LOCK_ON_50HZ:
-            return UserDefine.Boolean(UserDefineKey.LOCK_ON_50HZ);
-          // Compatibility options
-          case UserDefineKey.USE_UART2:
-            return UserDefine.Boolean(UserDefineKey.USE_UART2);
-          case UserDefineKey.UART_INVERTED:
-            return UserDefine.Boolean(UserDefineKey.UART_INVERTED, true);
-          case UserDefineKey.USE_R9MM_R9MINI_SBUS:
-            return UserDefine.Boolean(UserDefineKey.USE_R9MM_R9MINI_SBUS);
-          case UserDefineKey.RCVR_UART_BAUD:
-            return UserDefine.Text(UserDefineKey.RCVR_UART_BAUD, '420000');
-          case UserDefineKey.RCVR_INVERT_TX:
-            return UserDefine.Boolean(UserDefineKey.RCVR_INVERT_TX);
-          // Other options
-          case UserDefineKey.BLE_HID_JOYSTICK:
-            return UserDefine.Boolean(UserDefineKey.BLE_HID_JOYSTICK);
-          case UserDefineKey.USE_ESP8266_BACKPACK:
-            return UserDefine.Boolean(UserDefineKey.USE_ESP8266_BACKPACK, true);
-          case UserDefineKey.USE_TX_BACKPACK:
-            return UserDefine.Boolean(UserDefineKey.USE_TX_BACKPACK);
-          case UserDefineKey.JUST_BEEP_ONCE:
-            return UserDefine.Boolean(UserDefineKey.JUST_BEEP_ONCE);
-          case UserDefineKey.DISABLE_ALL_BEEPS:
-            return UserDefine.Boolean(UserDefineKey.DISABLE_ALL_BEEPS);
-          case UserDefineKey.DISABLE_STARTUP_BEEP:
-            return UserDefine.Boolean(UserDefineKey.DISABLE_STARTUP_BEEP);
-          case UserDefineKey.MY_STARTUP_MELODY:
-            return UserDefine.Text(UserDefineKey.MY_STARTUP_MELODY);
-          case UserDefineKey.USE_500HZ:
-            return UserDefine.Boolean(UserDefineKey.USE_500HZ);
-          case UserDefineKey.USE_DYNAMIC_POWER:
-            return UserDefine.Boolean(UserDefineKey.USE_DYNAMIC_POWER);
-          case UserDefineKey.WS2812_IS_GRB:
-            return UserDefine.Boolean(UserDefineKey.WS2812_IS_GRB);
-          // Network
-          case UserDefineKey.HOME_WIFI_SSID:
-            return UserDefine.Text(
-              UserDefineKey.HOME_WIFI_SSID,
-              '',
-              false,
-              true
-            );
-          case UserDefineKey.HOME_WIFI_PASSWORD:
-            return UserDefine.Text(
-              UserDefineKey.HOME_WIFI_PASSWORD,
-              '',
-              false,
-              true
-            );
-          case UserDefineKey.AUTO_WIFI_ON_BOOT:
-            return UserDefine.Boolean(UserDefineKey.AUTO_WIFI_ON_BOOT);
-          case UserDefineKey.AUTO_WIFI_ON_INTERVAL:
-            return UserDefine.Text(
-              UserDefineKey.AUTO_WIFI_ON_INTERVAL,
-              '60',
-              true
-            );
-          default:
-            throw new Error(`User Define ${userDefine} is not known`);
-        }
-      }
-    );
-
-    if (device === undefined) {
-      throw new Error(`device not found for target ${target}`);
+  build(userDefineKey: UserDefineKey): UserDefine {
+    switch (userDefineKey) {
+      // BINDING PHRASE
+      case UserDefineKey.BINDING_PHRASE:
+        return UserDefine.Text(UserDefineKey.BINDING_PHRASE, '', true, true);
+      // Regulatory domains
+      case UserDefineKey.REGULATORY_DOMAIN_AU_915:
+        return UserDefine.Boolean(
+          UserDefineKey.REGULATORY_DOMAIN_AU_915,
+          false,
+          UserDefineOptionGroup.RegulatoryDomain900
+        );
+      case UserDefineKey.REGULATORY_DOMAIN_EU_868:
+        return UserDefine.Boolean(
+          UserDefineKey.REGULATORY_DOMAIN_EU_868,
+          false,
+          UserDefineOptionGroup.RegulatoryDomain900
+        );
+      case UserDefineKey.REGULATORY_DOMAIN_IN_866:
+        return UserDefine.Boolean(
+          UserDefineKey.REGULATORY_DOMAIN_IN_866,
+          false,
+          UserDefineOptionGroup.RegulatoryDomain900
+        );
+      case UserDefineKey.REGULATORY_DOMAIN_AU_433:
+        return UserDefine.Boolean(UserDefineKey.REGULATORY_DOMAIN_AU_433);
+      case UserDefineKey.REGULATORY_DOMAIN_EU_433:
+        return UserDefine.Boolean(UserDefineKey.REGULATORY_DOMAIN_EU_433);
+      case UserDefineKey.REGULATORY_DOMAIN_FCC_915:
+        return UserDefine.Boolean(
+          UserDefineKey.REGULATORY_DOMAIN_FCC_915,
+          false,
+          UserDefineOptionGroup.RegulatoryDomain900
+        );
+      case UserDefineKey.REGULATORY_DOMAIN_ISM_2400:
+        return UserDefine.Boolean(
+          UserDefineKey.REGULATORY_DOMAIN_ISM_2400,
+          true,
+          UserDefineOptionGroup.RegulatoryDomain2400
+        );
+      case UserDefineKey.REGULATORY_DOMAIN_EU_CE_2400:
+        return UserDefine.Boolean(
+          UserDefineKey.REGULATORY_DOMAIN_EU_CE_2400,
+          true,
+          UserDefineOptionGroup.RegulatoryDomain2400
+        );
+      // Hybrid switches
+      case UserDefineKey.HYBRID_SWITCHES_8:
+        return UserDefine.Boolean(UserDefineKey.HYBRID_SWITCHES_8, true);
+      case UserDefineKey.ENABLE_TELEMETRY:
+        return UserDefine.Boolean(UserDefineKey.ENABLE_TELEMETRY);
+      case UserDefineKey.TLM_REPORT_INTERVAL_MS:
+        return UserDefine.Text(UserDefineKey.TLM_REPORT_INTERVAL_MS, '320LU');
+      // Performance options
+      case UserDefineKey.FAST_SYNC:
+        return UserDefine.Boolean(UserDefineKey.FAST_SYNC);
+      case UserDefineKey.R9M_UNLOCK_HIGHER_POWER:
+        return UserDefine.Boolean(UserDefineKey.R9M_UNLOCK_HIGHER_POWER);
+      case UserDefineKey.UNLOCK_HIGHER_POWER:
+        return UserDefine.Boolean(UserDefineKey.UNLOCK_HIGHER_POWER, true);
+      case UserDefineKey.USE_DIVERSITY:
+        return UserDefine.Boolean(UserDefineKey.USE_DIVERSITY);
+      case UserDefineKey.NO_SYNC_ON_ARM:
+        return UserDefine.Boolean(UserDefineKey.NO_SYNC_ON_ARM);
+      case UserDefineKey.ARM_CHANNEL:
+        return UserDefine.Enum(
+          UserDefineKey.ARM_CHANNEL,
+          ['AUX1', 'AUX2', 'AUX3', 'AUX4', 'AUX5', 'AUX6'],
+          'AUX1'
+        );
+      case UserDefineKey.FEATURE_OPENTX_SYNC:
+        return UserDefine.Boolean(UserDefineKey.FEATURE_OPENTX_SYNC, true);
+      case UserDefineKey.FEATURE_OPENTX_SYNC_AUTOTUNE:
+        return UserDefine.Boolean(UserDefineKey.FEATURE_OPENTX_SYNC_AUTOTUNE);
+      case UserDefineKey.LOCK_ON_FIRST_CONNECTION:
+        return UserDefine.Boolean(UserDefineKey.LOCK_ON_FIRST_CONNECTION, true);
+      case UserDefineKey.LOCK_ON_50HZ:
+        return UserDefine.Boolean(UserDefineKey.LOCK_ON_50HZ);
+      // Compatibility options
+      case UserDefineKey.USE_UART2:
+        return UserDefine.Boolean(UserDefineKey.USE_UART2);
+      case UserDefineKey.UART_INVERTED:
+        return UserDefine.Boolean(UserDefineKey.UART_INVERTED, true);
+      case UserDefineKey.USE_R9MM_R9MINI_SBUS:
+        return UserDefine.Boolean(UserDefineKey.USE_R9MM_R9MINI_SBUS);
+      case UserDefineKey.RCVR_UART_BAUD:
+        return UserDefine.Text(UserDefineKey.RCVR_UART_BAUD, '420000');
+      case UserDefineKey.RCVR_INVERT_TX:
+        return UserDefine.Boolean(UserDefineKey.RCVR_INVERT_TX);
+      // Other options
+      case UserDefineKey.BLE_HID_JOYSTICK:
+        return UserDefine.Boolean(UserDefineKey.BLE_HID_JOYSTICK);
+      case UserDefineKey.USE_ESP8266_BACKPACK:
+        return UserDefine.Boolean(UserDefineKey.USE_ESP8266_BACKPACK, true);
+      case UserDefineKey.USE_TX_BACKPACK:
+        return UserDefine.Boolean(UserDefineKey.USE_TX_BACKPACK);
+      case UserDefineKey.JUST_BEEP_ONCE:
+        return UserDefine.Boolean(UserDefineKey.JUST_BEEP_ONCE);
+      case UserDefineKey.DISABLE_ALL_BEEPS:
+        return UserDefine.Boolean(UserDefineKey.DISABLE_ALL_BEEPS);
+      case UserDefineKey.DISABLE_STARTUP_BEEP:
+        return UserDefine.Boolean(UserDefineKey.DISABLE_STARTUP_BEEP);
+      case UserDefineKey.MY_STARTUP_MELODY:
+        return UserDefine.Text(UserDefineKey.MY_STARTUP_MELODY);
+      case UserDefineKey.USE_500HZ:
+        return UserDefine.Boolean(UserDefineKey.USE_500HZ);
+      case UserDefineKey.USE_DYNAMIC_POWER:
+        return UserDefine.Boolean(UserDefineKey.USE_DYNAMIC_POWER);
+      case UserDefineKey.WS2812_IS_GRB:
+        return UserDefine.Boolean(UserDefineKey.WS2812_IS_GRB);
+      // Network
+      case UserDefineKey.HOME_WIFI_SSID:
+        return UserDefine.Text(UserDefineKey.HOME_WIFI_SSID, '', false, true);
+      case UserDefineKey.HOME_WIFI_PASSWORD:
+        return UserDefine.Text(
+          UserDefineKey.HOME_WIFI_PASSWORD,
+          '',
+          false,
+          true
+        );
+        break;
+      case UserDefineKey.AUTO_WIFI_ON_BOOT:
+        return UserDefine.Boolean(UserDefineKey.AUTO_WIFI_ON_BOOT);
+      case UserDefineKey.AUTO_WIFI_ON_INTERVAL:
+        return UserDefine.Text(UserDefineKey.AUTO_WIFI_ON_INTERVAL, '60', true);
+      default:
+        throw new Error(`User Define ${userDefineKey} is not known`);
     }
-
-    return userDefines || [];
   }
 }

--- a/src/api/src/models/Device.ts
+++ b/src/api/src/models/Device.ts
@@ -1,7 +1,7 @@
 import { Field, ObjectType } from 'type-graphql';
-import UserDefineKey from '../library/FirmwareBuilder/Enum/UserDefineKey';
 import DeviceType from './enum/DeviceType';
 import Target from './Target';
+import UserDefine from './UserDefine';
 
 @ObjectType('Device')
 export default class Device {
@@ -17,8 +17,8 @@ export default class Device {
   @Field(() => [Target])
   targets: Target[];
 
-  @Field(() => [UserDefineKey])
-  userDefines: UserDefineKey[];
+  @Field(() => [UserDefine])
+  userDefines: UserDefine[];
 
   @Field({ nullable: true })
   wikiUrl?: string;
@@ -40,7 +40,7 @@ export default class Device {
     name: string,
     category: string,
     targets: Target[],
-    userDefines: UserDefineKey[],
+    userDefines: UserDefine[],
     deviceType: DeviceType,
     verifiedHardware: boolean,
     wikiUrl?: string,

--- a/src/api/src/models/UserDefineOverride.ts
+++ b/src/api/src/models/UserDefineOverride.ts
@@ -1,0 +1,15 @@
+import UserDefineOptionGroup from './enum/UserDefineOptionGroup';
+
+export default interface UserDefineOverride {
+  key: string;
+
+  enabled?: boolean;
+
+  sensitive?: boolean;
+
+  enumValues?: string[];
+
+  value?: string;
+
+  optionGroup?: UserDefineOptionGroup;
+}

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -94,7 +94,7 @@ export type Device = {
   readonly name: Scalars['String'];
   readonly category: Scalars['String'];
   readonly targets: ReadonlyArray<Target>;
-  readonly userDefines: ReadonlyArray<UserDefineKey>;
+  readonly userDefines: ReadonlyArray<UserDefine>;
   readonly wikiUrl?: Maybe<Scalars['String']>;
   readonly deviceType: DeviceType;
   readonly verifiedHardware: Scalars['Boolean'];
@@ -118,6 +118,23 @@ export enum FlashingMethod {
   WIFI = 'WIFI',
   EdgeTxPassthrough = 'EdgeTxPassthrough',
   Radio = 'Radio',
+}
+
+export type UserDefine = {
+  readonly __typename?: 'UserDefine';
+  readonly type: UserDefineKind;
+  readonly key: UserDefineKey;
+  readonly enabled: Scalars['Boolean'];
+  readonly sensitive: Scalars['Boolean'];
+  readonly enumValues?: Maybe<ReadonlyArray<Scalars['String']>>;
+  readonly value?: Maybe<Scalars['String']>;
+  readonly optionGroup?: Maybe<UserDefineOptionGroup>;
+};
+
+export enum UserDefineKind {
+  Boolean = 'Boolean',
+  Text = 'Text',
+  Enum = 'Enum',
 }
 
 export enum UserDefineKey {
@@ -165,6 +182,11 @@ export enum UserDefineKey {
   DEVICE_NAME = 'DEVICE_NAME',
 }
 
+export enum UserDefineOptionGroup {
+  RegulatoryDomain900 = 'RegulatoryDomain900',
+  RegulatoryDomain2400 = 'RegulatoryDomain2400',
+}
+
 export enum DeviceType {
   ExpressLRS = 'ExpressLRS',
   Backpack = 'Backpack',
@@ -192,28 +214,6 @@ export type PullRequestInput = {
   readonly number: Scalars['Float'];
   readonly headCommitHash: Scalars['String'];
 };
-
-export type UserDefine = {
-  readonly __typename?: 'UserDefine';
-  readonly type: UserDefineKind;
-  readonly key: UserDefineKey;
-  readonly enabled: Scalars['Boolean'];
-  readonly sensitive: Scalars['Boolean'];
-  readonly enumValues?: Maybe<ReadonlyArray<Scalars['String']>>;
-  readonly value?: Maybe<Scalars['String']>;
-  readonly optionGroup?: Maybe<UserDefineOptionGroup>;
-};
-
-export enum UserDefineKind {
-  Boolean = 'Boolean',
-  Text = 'Text',
-  Enum = 'Enum',
-}
-
-export enum UserDefineOptionGroup {
-  RegulatoryDomain900 = 'RegulatoryDomain900',
-  RegulatoryDomain2400 = 'RegulatoryDomain2400',
-}
 
 export type Release = {
   readonly __typename?: 'Release';
@@ -461,7 +461,6 @@ export type AvailableFirmwareTargetsQuery = {
       | 'name'
       | 'category'
       | 'wikiUrl'
-      | 'userDefines'
       | 'deviceType'
       | 'parent'
       | 'abbreviatedName'
@@ -842,7 +841,6 @@ export const AvailableFirmwareTargetsDocument = gql`
         flashingMethod
       }
       wikiUrl
-      userDefines
       deviceType
       parent
       abbreviatedName

--- a/src/ui/gql/queries/availableFirmwareTargets.graphql
+++ b/src/ui/gql/queries/availableFirmwareTargets.graphql
@@ -25,7 +25,6 @@ query availableFirmwareTargets(
       flashingMethod
     }
     wikiUrl
-    userDefines
     deviceType
     parent
     abbreviatedName


### PR DESCRIPTION
Alter the userDefines array in the configuration file to be either a string or a UserDefineOverride object that provides the ability to change the default value of a user define.

![image](https://user-images.githubusercontent.com/38869875/163658037-b520e2ca-b043-435b-b25a-c05899711c69.png)

To support device specific overrides of user defines, the DeviceService now fully builds out the user defines for each device and applies the overrides included in the configuration file, instead of just keeping a list of UserDefineKeys that the device supports.  The UserDefinesBuilder no longer needs the TargetUserDefinesFactory to generate the UserDefines since it can get them from the device object itself, so the TargetUserDefineFactory has been changed from being a service to a regular class that is used by the DeviceService.
