### PR TITLE
Update on Devices WikiURLs

### DIFF
--- a/devices/axis-2400.json
+++ b/devices/axis-2400.json
@@ -30,7 +30,7 @@
       "BLE_HID_JOYSTICK",
       "USE_DYNAMIC_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-axis-thor/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/axis-thor/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -67,7 +67,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-axis-thor/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/axis-thor/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/axis-backpack.json
+++ b/devices/axis-backpack.json
@@ -17,7 +17,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-axis-thor/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/axis-thor/",
     "deviceType": "Backpack",
     "aliases": []
   }

--- a/devices/betafpv-2400.json
+++ b/devices/betafpv-2400.json
@@ -32,7 +32,7 @@
       "WS2812_IS_GRB",
       "UNLOCK_HIGHER_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/betafpv2400/",
     "deviceType": "ExpressLRS",
     "aliases": [
       {
@@ -77,7 +77,7 @@
       "WS2812_IS_GRB",
       "UNLOCK_HIGHER_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/betafpv2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -108,7 +108,7 @@
       "BLE_HID_JOYSTICK",
       "USE_DYNAMIC_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/betafpv2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -157,7 +157,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-betafpv2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/betafpv2400/",
     "deviceType": "ExpressLRS",
     "aliases": [
       {

--- a/devices/betafpv-900.json
+++ b/devices/betafpv-900.json
@@ -33,7 +33,7 @@
       "HOME_WIFI_PASSWORD",
       "UNLOCK_HIGHER_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/betafpv900/",
     "deviceType": "ExpressLRS",
     "aliases": [
       {
@@ -79,7 +79,7 @@
       "HOME_WIFI_PASSWORD",
       "UNLOCK_HIGHER_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-betafpv900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/betafpv900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -117,7 +117,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-betafpv900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/betafpv900/",
     "deviceType": "ExpressLRS",
     "aliases": [
       {

--- a/devices/diy-2400.json
+++ b/devices/diy-2400.json
@@ -31,7 +31,7 @@
       "USE_DYNAMIC_POWER",
       "WS2812_IS_GRB"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/diy2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -68,7 +68,7 @@
       "USE_DYNAMIC_POWER",
       "WS2812_IS_GRB"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/diy2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -102,12 +102,12 @@
       "BLE_HID_JOYSTICK",
       "USE_DYNAMIC_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/diy2400/",
     "deviceType": "ExpressLRS",
     "aliases": [{
       "category": "RadioMaster 2.4 GHz",
       "name": "RadioMaster Zorro 2400 TX",
-      "wikiUrl": "",
+	  "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/rm-internal/",
       "abbreviatedName": "RM Zorro 2400TX"
     }]
   },
@@ -143,7 +143,7 @@
       "USE_DYNAMIC_POWER",
       "WS2812_IS_GRB"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/diy2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -180,7 +180,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/diy2400/",
     "deviceType": "ExpressLRS",
     "aliases": [
       {
@@ -228,13 +228,13 @@
       {
         "category": "Jumper 2.4 GHz",
         "name": "Jumper AION Mini 2400 RX",
-        "wikiUrl": "",
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/jumper-aion/",
         "abbreviatedName": "AION RX24 MINI"
       },
       {
         "category": "BETAFPV 2.4 GHz",
         "name": "BETAFPV Lite 2400 RX",
-        "wikiUrl": "",
+		"wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/betafpv2400/",
         "abbreviatedName": "BFPV Lite 2G4RX"
       }
     ]
@@ -265,7 +265,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/diy2400/",
     "deviceType": "ExpressLRS",
     "aliases": [{
       "category": "BETAFPV 2.4 GHz",
@@ -297,7 +297,7 @@
       "USE_500HZ",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/diy2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/diy-900.json
+++ b/devices/diy-900.json
@@ -30,7 +30,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/diy900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -65,7 +65,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/diy900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -103,7 +103,7 @@
       "HOME_WIFI_PASSWORD",
       "UNLOCK_HIGHER_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/diy900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -140,7 +140,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-diy900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/diy900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -178,7 +178,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/diy900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -210,7 +210,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-diyreceivers900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/diy900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/frsky-900.json
+++ b/devices/frsky-900.json
@@ -38,7 +38,7 @@
       "UNLOCK_HIGHER_POWER",
       "USE_TX_BACKPACK"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/frsky-r9modules/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -72,7 +72,7 @@
       "DISABLE_ALL_BEEPS",
       "USE_DYNAMIC_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/frsky-r9modules/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -103,7 +103,7 @@
       "DISABLE_ALL_BEEPS",
       "USE_DYNAMIC_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-r9m/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/frsky-r9modules/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -133,7 +133,7 @@
       "USE_R9MM_R9MINI_SBUS",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/r9/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -163,7 +163,7 @@
       "USE_DIVERSITY",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/r9/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -192,7 +192,7 @@
       "LOCK_ON_FIRST_CONNECTION",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/r9/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -222,7 +222,7 @@
       "USE_DIVERSITY",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/r9/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -251,7 +251,7 @@
       "LOCK_ON_FIRST_CONNECTION",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-r9receivers/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/r9/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/ghost-2400.json
+++ b/devices/ghost-2400.json
@@ -29,7 +29,7 @@
       "DISABLE_ALL_BEEPS",
       "MY_STARTUP_MELODY"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-ghost2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/ghost2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -63,7 +63,7 @@
       "DISABLE_ALL_BEEPS",
       "MY_STARTUP_MELODY"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-ghost2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/ghost2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -90,7 +90,7 @@
       "USE_500HZ",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-ghost2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/ghost2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/happymodel-2400.json
+++ b/devices/happymodel-2400.json
@@ -31,7 +31,7 @@
       "USE_DYNAMIC_POWER",
       "WS2812_IS_GRB"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/es24tx/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -67,7 +67,7 @@
       "USE_DYNAMIC_POWER",
       "WS2812_IS_GRB"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/es24tx/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -102,7 +102,7 @@
       "USE_DYNAMIC_POWER",
       "WS2812_IS_GRB"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es24tx/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/es24tx/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -138,7 +138,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmep2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/hmep2400/",
     "deviceType": "ExpressLRS",
     "aliases": [
       {
@@ -172,7 +172,7 @@
       "USE_500HZ",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmpp2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/hmpp2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/happymodel-900.json
+++ b/devices/happymodel-900.json
@@ -32,7 +32,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-es900tx/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/es900tx/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -70,7 +70,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-hmes900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/hmes900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },

--- a/devices/jumper-2400.json
+++ b/devices/jumper-2400.json
@@ -26,7 +26,7 @@
       "BLE_HID_JOYSTICK",
       "USE_DYNAMIC_POWER"
     ],
-    "wikiUrl": "",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/jumper-aion/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -58,7 +58,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/aion-internal/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/jumper-900.json
+++ b/devices/jumper-900.json
@@ -24,7 +24,7 @@
       "LOCK_ON_FIRST_CONNECTION",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-jumper900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/jumper900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/matek-2400.json
+++ b/devices/matek-2400.json
@@ -32,7 +32,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-matek2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/matek2400/",
     "deviceType": "ExpressLRS",
     "aliases": [
       {

--- a/devices/namimnorc-2400.json
+++ b/devices/namimnorc-2400.json
@@ -29,7 +29,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-flash2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/flash2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -63,7 +63,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-flash2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/flash2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -90,7 +90,7 @@
       "USE_500HZ",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-flash2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/flash2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -126,7 +126,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-flash2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/flash2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },{
@@ -162,7 +162,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-flash2400/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/flash2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/namimnorc-900.json
+++ b/devices/namimnorc-900.json
@@ -29,7 +29,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-voyager900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/voyager900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -63,7 +63,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-voyager900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/voyager900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -92,7 +92,7 @@
       "LOCK_ON_FIRST_CONNECTION",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-voyager900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/voyager900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -130,7 +130,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-voyager900/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/voyager900/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/radiomaster-2400.json
+++ b/devices/radiomaster-2400.json
@@ -26,7 +26,7 @@
       "HOME_WIFI_SSID",
       "HOME_WIFI_PASSWORD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-rm-internal/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/rm-internal/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/siyi-2400.json
+++ b/devices/siyi-2400.json
@@ -26,7 +26,7 @@
       "UART_INVERTED",
       "USE_DYNAMIC_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/tx-siyifm30/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/siyifm30/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -54,7 +54,7 @@
       "USE_DIVERSITY",
       "RCVR_UART_BAUD"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-siyiFRmini/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/siyiFRmini/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -85,7 +85,7 @@
       "UART_INVERTED",
       "USE_DYNAMIC_POWER"
     ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/rx-siyiFRmini/",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/siyiFRmini/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }

--- a/devices/vantac-2400.json
+++ b/devices/vantac-2400.json
@@ -26,7 +26,7 @@
       "BLE_HID_JOYSTICK",
       "USE_DYNAMIC_POWER"
     ],
-    "wikiUrl": "",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/vantac2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   },
@@ -58,7 +58,7 @@
       "RCVR_UART_BAUD",
       "RCVR_INVERT_TX"
     ],
-    "wikiUrl": "",
+    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/vantac2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
   }


### PR DESCRIPTION
With the update on the Docs via PR [#197](https://github.com/ExpressLRS/Docs/pull/197) as per issue #326 
I have updated each of the devices WikiURL properties.
I have tested the changes via local yarn start and the links resolve to the right links.

Do verify that is the case.
Let me know of any changes/corrections.