### PR TITLE
Added Orqa FPV.Connect ESP Backpack target

### DIFF
--- a/devices/orqa-backpack.json
+++ b/devices/orqa-backpack.json
@@ -1,0 +1,24 @@
+[
+  {
+    "category": "Goggles",
+    "name": "Orqa FPV.Connect ESP Backpack",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "Orqa_ESP_RX_Backpack_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "Orqa_ESP_RX_Backpack_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "BINDING_PHRASE",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "https://github.com/ExpressLRS/Backpack/wiki/Orqa-FPV.Connect-Wiring",
+    "deviceType": "Backpack",
+    "aliases": []
+  }
+]


### PR DESCRIPTION
Add the option to target the FPV.Connect Backpack (https://github.com/ExpressLRS/Backpack/pull/70).
Can I just add a category for "Goggles" like this?