### PR TITLE
Use lint-staged and eslint --fix

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn run lint
+yarn lint-staged
+

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "build:renderer": "cross-env NODE_ENV=production webpack --config ./.erb/configs/webpack.config.renderer.prod.babel.js",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir src",
     "lint": "cross-env NODE_ENV=development eslint . --cache --ext .js,.jsx,.ts,.tsx",
+    "lint:fix": "yarn lint --fix",
     "package": "yarn build && electron-builder build --publish never",
     "postinstall": "node -r @babel/register .erb/scripts/CheckNativeDep.js && electron-builder install-app-deps && yarn build-dll && yarn-deduplicate yarn.lock",
     "start": "node -r @babel/register ./.erb/scripts/CheckPortInUse.js && cross-env yarn start:renderer",
     "start:main": "cross-env NODE_ENV=development electron -r ./.erb/scripts/BabelRegister ./src/main.dev.ts",
     "start:renderer": "cross-env NODE_ENV=development webpack serve --config ./.erb/configs/webpack.config.renderer.dev.babel.js",
     "test": "jest --passWithNoTests",
-    "gql-codegen": "graphql-codegen --config codegen.yml",
+    "gql-codegen": "graphql-codegen --config codegen.yml && yarn lint:fix",
     "prepare": "husky install"
   },
   "author": {
@@ -25,7 +26,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "cross-env NODE_ENV=development eslint --cache"
+      "cross-env NODE_ENV=development eslint --cache --fix"
     ],
     "{*.json,.{babelrc,eslintrc,prettierrc}}": [
       "prettier --ignore-path .eslintignore --parser json --write"


### PR DESCRIPTION
- Change husky's pre-commit hook to use lint-staged so eslint is only ran against the staged files instead of the whole project and also have eslint automatically fix the errors it can
- Add a new script lint:fix that runs eslint --fix
- Automatically run lint:fix after graphql-codegen to fix the formatting of the generated files