### PR TITLE
Refactor progress notifications and build logs subscriptions

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -16,6 +16,8 @@ import { DeviceType, MulticastDnsInformation } from './gql/generated/types';
 import useNetworkDevices from './hooks/useNetworkDevices';
 import WifiDeviceNotification from './components/WifiDeviceNotification';
 import AppStateProvider from './context/AppStateProvider';
+import useBuildProgressNotifications from './hooks/useBuildProgressNotifications';
+import useBuildLogs from './hooks/useBuildLogs';
 
 const App = () => {
   const { networkDevices, newNetworkDevices, removeDeviceFromNewList } =
@@ -39,6 +41,14 @@ const App = () => {
     []
   );
 
+  const {
+    buildProgressNotifications,
+    lastBuildProgressNotification,
+    resetBuildProgressNotifications,
+  } = useBuildProgressNotifications();
+
+  const { buildLogs, resetLogs } = useBuildLogs();
+
   return (
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>
@@ -61,6 +71,15 @@ const App = () => {
                       networkDevices={networkDevices}
                       onDeviceChange={onDeviceChange}
                       deviceType={DeviceType.ExpressLRS}
+                      buildProgressNotifications={buildProgressNotifications}
+                      lastBuildProgressNotification={
+                        lastBuildProgressNotification
+                      }
+                      resetBuildProgressNotifications={
+                        resetBuildProgressNotifications
+                      }
+                      buildLogs={buildLogs}
+                      resetBuildLogs={resetLogs}
                     />
                   }
                 />
@@ -74,6 +93,15 @@ const App = () => {
                       networkDevices={networkDevices}
                       onDeviceChange={onDeviceChange}
                       deviceType={DeviceType.Backpack}
+                      buildProgressNotifications={buildProgressNotifications}
+                      lastBuildProgressNotification={
+                        lastBuildProgressNotification
+                      }
+                      resetBuildProgressNotifications={
+                        resetBuildProgressNotifications
+                      }
+                      buildLogs={buildLogs}
+                      resetBuildLogs={resetLogs}
                     />
                   }
                 />

--- a/src/ui/hooks/useBuildLogs.tsx
+++ b/src/ui/hooks/useBuildLogs.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+import { useBuildLogUpdatesSubscription } from '../gql/generated/types';
+import client from '../gql';
+import EventsBatcher from '../library/EventsBatcher';
+
+export default function useBuildLogs() {
+  /*
+    We batch log events in order to save React.js state updates and rendering performance.
+   */
+  const [buildLogs, setLogs] = useState<string>('');
+  const logsRef = useRef<string[]>([]);
+  const eventsBatcherRef = useRef<EventsBatcher<string> | null>(null);
+  useEffect(() => {
+    eventsBatcherRef.current = new EventsBatcher<string>(200);
+    eventsBatcherRef.current.onBatch((newLogs) => {
+      const newLogsList = [...logsRef.current, ...newLogs];
+      logsRef.current = newLogsList;
+      setLogs(newLogsList.join(''));
+    });
+  }, []);
+  useBuildLogUpdatesSubscription({
+    fetchPolicy: 'network-only',
+    client,
+    onSubscriptionData: (options) => {
+      const args = options.subscriptionData.data?.buildLogUpdates.data;
+      if (args !== undefined && eventsBatcherRef.current !== null) {
+        eventsBatcherRef.current.enqueue(args);
+      }
+    },
+  });
+
+  const resetLogs = () => {
+    logsRef.current = [];
+    setLogs('');
+  };
+
+  return {
+    buildLogs,
+    resetLogs,
+  };
+}

--- a/src/ui/hooks/useBuildProgressNotifications.tsx
+++ b/src/ui/hooks/useBuildProgressNotifications.tsx
@@ -1,0 +1,43 @@
+import { useRef, useState } from 'react';
+import {
+  BuildProgressNotification,
+  useBuildProgressNotificationsSubscription,
+} from '../gql/generated/types';
+import client from '../gql';
+
+export default function useBuildProgressNotifications() {
+  const [buildProgressNotifications, setBuildProgressNotifications] = useState<
+    BuildProgressNotification[]
+  >([]);
+  const buildProgressNotificationsRef = useRef<BuildProgressNotification[]>([]);
+  const [lastBuildProgressNotification, setLastBuildProgressNotification] =
+    useState<BuildProgressNotification | null>(null);
+
+  useBuildProgressNotificationsSubscription({
+    client,
+    onSubscriptionData: (options) => {
+      const args = options.subscriptionData.data?.buildProgressNotifications;
+      if (args !== undefined) {
+        const newNotificationsList = [
+          ...buildProgressNotificationsRef.current,
+          args,
+        ];
+        buildProgressNotificationsRef.current = newNotificationsList;
+        setBuildProgressNotifications(newNotificationsList);
+        setLastBuildProgressNotification(args);
+      }
+    },
+  });
+
+  const resetBuildProgressNotifications = () => {
+    buildProgressNotificationsRef.current = [];
+    setBuildProgressNotifications([]);
+    setLastBuildProgressNotification(null);
+  };
+
+  return {
+    buildProgressNotifications,
+    lastBuildProgressNotification,
+    resetBuildProgressNotifications,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@apollo/client@^3.6.9":
+"@apollo/client@^3.6.7":
   version "3.6.9"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.9.tgz#ad0ee2e3a3c92dbed4acd6917b6158a492739d94"
   integrity sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==
@@ -3406,11 +3406,11 @@
   integrity sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==
 
 "@wry/context@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.0.tgz#f903eceb89d238ef7e8168ed30f4511f92d83e06"
-  integrity sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
+  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
   dependencies:
-    tslib "^2.1.0"
+    tslib "^2.3.0"
 
 "@wry/equality@^0.5.0":
   version "0.5.2"
@@ -3420,11 +3420,11 @@
     tslib "^2.3.0"
 
 "@wry/trie@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.0.tgz#3245e74988c4e3033299e479a1bf004430752463"
-  integrity sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.1.tgz#2279b790f15032f8bcea7fc944d27988e5b3b139"
+  integrity sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==
   dependencies:
-    tslib "^2.1.0"
+    tslib "^2.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -9280,7 +9280,7 @@ number-is-nan@^1.0.0:
 object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-inspect@^1.12.0, object-inspect@^1.12.2, object-inspect@^1.9.0:
   version "1.12.2"


### PR DESCRIPTION
There is an issue with Apollo GraphQL subscriptions when used with React v18 in which a subscription cannot be subscribed to again, this is causing issues with the configurator view which is used for both the TX/RX and the backpack configuration and uses the progress notifications and build logs subscriptions.  This PR moves those subscriptions to the app layer and passes down the data to the view so it is not necessary to resubscribe to the subscriptions when the view changes.

See https://github.com/apollographql/apollo-client/issues/9664 for the Apollo issue.