### PR TITLE
Add REGULATORY_DOMAIN_EU_CE_2400 back to the TXs that didn't support 10mw

### DIFF
--- a/devices/happymodel-2400.json
+++ b/devices/happymodel-2400.json
@@ -86,6 +86,7 @@
     ],
     "userDefines": [
       "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
       "BINDING_PHRASE",
       "HYBRID_SWITCHES_8",
       "ENABLE_TELEMETRY",

--- a/devices/namimnorc-2400.json
+++ b/devices/namimnorc-2400.json
@@ -14,6 +14,7 @@
     ],
     "userDefines": [
       "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
       "BINDING_PHRASE",
       "HYBRID_SWITCHES_8",
       "ENABLE_TELEMETRY",
@@ -48,6 +49,7 @@
     ],
     "userDefines": [
       "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
       "BINDING_PHRASE",
       "HYBRID_SWITCHES_8",
       "ENABLE_TELEMETRY",
@@ -129,7 +131,8 @@
     "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/flash2400/",
     "deviceType": "ExpressLRS",
     "aliases": []
-  },{
+  },
+  {
     "category": "NamimnoRC FLASH 2.4 GHz",
     "name": "NamimnoRC FLASH 2400 ESP Diversity RX",
     "targets": [
@@ -154,7 +157,7 @@
       "ENABLE_TELEMETRY",
       "LOCK_ON_FIRST_CONNECTION",
       "USE_500HZ",
-      {"key": "USE_DIVERSITY", "enabled": true},
+      { "key": "USE_DIVERSITY", "enabled": true },
       "AUTO_WIFI_ON_BOOT",
       "AUTO_WIFI_ON_INTERVAL",
       "HOME_WIFI_SSID",


### PR DESCRIPTION
REGULATORY_DOMAIN_EU_CE_2400 was not included on the HM ES24TX Pro Series 2400 TX, NamimnoRC FLASH 2400 TX, and NamimnoRC FLASH 2400 OLED TX devices since they did not support 10mw.  REGULATORY_DOMAIN_EU_CE_2400 can now be added to those devices since v3 of the firmware includes support for LBT.  This will have the side effect of making this option available on older firmware which don't technically support it, but there is no easy way to solve for that.