### PR TITLE
Update RadioMaster RP1/2 and add RP3

### DIFF
--- a/devices/happymodel-2400.json
+++ b/devices/happymodel-2400.json
@@ -143,9 +143,9 @@
     "aliases": [
       {
         "category": "RadioMaster 2.4 GHz",
-        "name": "RadioMaster EP 2400 RX",
+        "name": "RadioMaster RP1/2 2400 RX",
         "wikiUrl": "",
-        "abbreviatedName": "RM EP 2400RX"
+        "abbreviatedName": "RM RP 2400RX"
       }
     ]
   },

--- a/devices/matek-2400.json
+++ b/devices/matek-2400.json
@@ -109,6 +109,12 @@
     ],
     "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/matek2400/",
     "deviceType": "ExpressLRS",
-    "aliases": []
-  }
+    "aliases": [
+      {
+        "category": "RadioMaster 2.4 GHz",
+        "name": "RadioMaster RP3 Diversiry 2400 RX",
+        "wikiUrl": "",
+        "abbreviatedName": "RM RP3 2400RX"
+      }
+    ]  }
 ]


### PR DESCRIPTION
The RadioMaster RXes are actually called RP1 and RP2, so these have been updated.
Also added the new RP3 diversity RX.
