### PR TITLE
Fix label for CE domain

### DIFF
--- a/src/ui/components/UserDefineDescription/index.tsx
+++ b/src/ui/components/UserDefineDescription/index.tsx
@@ -79,9 +79,11 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> =
           return (
             <div>
               <p>
-                EU CE 2.4 GHz regulatory domain is the same as ISM 2.4 GHz
-                regulatory domain but is limited to 100mW output, and uses LBT
-                (Listen Before Talk).
+                For firmware versions earlier than v3.x, the EU CE 2.4 GHz
+                regulatory domain limits the maxmimum power to 10mW, which does
+                not require LBT (Listen Before Talk). For firmware versions
+                later than v3.x, the EU CE 2.4 GHz regulatory domain limits the
+                maxmimum power to 100mW, and enables LBT (Listen Before Talk).
               </p>
               <p>
                 <a

--- a/src/ui/components/UserDefineDescription/index.tsx
+++ b/src/ui/components/UserDefineDescription/index.tsx
@@ -80,7 +80,8 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> =
             <div>
               <p>
                 EU CE 2.4 GHz regulatory domain is the same as ISM 2.4 GHz
-                regulatory domain but limited to 10mW output.
+                regulatory domain but is limited to 100mW output, and uses LBT
+                (Listen Before Talk).
               </p>
               <p>
                 <a


### PR DESCRIPTION
CE is now capped at 100mW (previously 10mW), and uses LBT.
![Screenshot_1](https://user-images.githubusercontent.com/59873510/179494640-252941ce-d19b-411e-a62d-711e10215ad5.png)

