### PR TITLE
Adds TX12 Alias Target

### DIFF
--- a/devices/radiomaster-2400.json
+++ b/devices/radiomaster-2400.json
@@ -62,6 +62,13 @@
     ],
     "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/rm-internal/",
     "deviceType": "ExpressLRS",
-    "aliases": []
+    "aliases": [
+      {
+        "category": "RadioMaster 2.4 GHz",
+        "name": "RadioMaster TX12 2400 TX",
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/rm-internal/",
+        "abbreviatedName": "RadioMstr TX12"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This adds a Device Target on the Configurator for the TX12 with Internal ELRS  module.
It is an Alias of the Zorro Target, so it will build the Zorro binary.
They are essentially the same and is interchangeable. This PR aims to lessen user confusion by providing specific Device Target for the TX12, until Unified Targets are incorporated into the Configurator.