### PR TITLE
Add EMAX targets

### DIFF
--- a/devices/betafpv-2400.json
+++ b/devices/betafpv-2400.json
@@ -205,6 +205,12 @@
         "wikiUrl": "",
         "abbreviatedName": "JHEMCU RX24T",
         "verifiedHardware": false
+      },
+      {
+        "category": "EMAX 2.4 GHz",
+        "name": "EMAX 2.4GHz PA RX",
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/diy2400/",
+        "abbreviatedName": "EMAX 2400RX"
       }
     ]
   }

--- a/devices/diy-2400.json
+++ b/devices/diy-2400.json
@@ -237,6 +237,12 @@
         "name": "GEPRC Nano 2400 RX",
         "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/geprc2400/",
         "abbreviatedName": "GEPRC Nano 2G4RX"
+      },
+      {
+        "category": "EMAX 2.4 GHz",
+        "name": "EMAX 2.4GHz RX",
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/diy2400/",
+        "abbreviatedName": "EMAX 2400RX"
       }
     ]
   },

--- a/devices/diy-900.json
+++ b/devices/diy-900.json
@@ -186,6 +186,12 @@
         "name": "GEPRC Nano 900 RX",
         "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/geprc900/",
         "abbreviatedName": "GEPRC Nano 900RX"
+      },
+      {
+        "category": "EMAX 900 MHz",
+        "name": "EMAX 900MHz RX",
+        "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/receivers/diy900/",
+        "abbreviatedName": "EMAX 900RX"
       }
 	]
   },

--- a/devices/emax-2400.json
+++ b/devices/emax-2400.json
@@ -1,0 +1,38 @@
+[
+  {
+    "category": "EMAX 2.4 GHz",
+    "name": "EMAX OLED 2.4GHz TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "EMAX_2400_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "EMAX_2400_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "TLM_REPORT_INTERVAL_MS",
+      "NO_SYNC_ON_ARM",
+      "ARM_CHANNEL",
+      "FEATURE_OPENTX_SYNC",
+      "USE_500HZ",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "BLE_HID_JOYSTICK",
+      "USE_DYNAMIC_POWER",
+      "WS2812_IS_GRB"
+    ],
+    "wikiUrl": "",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
+]

--- a/devices/emax-900.json
+++ b/devices/emax-900.json
@@ -1,0 +1,36 @@
+[
+  {
+    "category": "EMAX 900 MHz",
+    "name": "EMAX OLED 900MHz TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "EMAX_900_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "EMAX_900_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "HYBRID_SWITCHES_8",
+      "ENABLE_TELEMETRY",
+      "ARM_CHANNEL",
+      "LOCK_ON_FIRST_CONNECTION",
+      "AUTO_WIFI_ON_BOOT",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD",
+      "RCVR_UART_BAUD",
+      "RCVR_INVERT_TX"
+    ],
+    "wikiUrl": "",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  }
+]


### PR DESCRIPTION
Adds new targets for 2 TX modules, 2.4GHZ and 900MHz.
Also add aliases for 3 RX devices. 2 x 2.4Ghz, a "plain jane" and a PA version, and one 900MHz "plain jane" version.
