### PR TITLE
UserDefineDescription updates

### DIFF
--- a/src/ui/components/UserDefineDescription/index.tsx
+++ b/src/ui/components/UserDefineDescription/index.tsx
@@ -425,8 +425,8 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> =
             <div>
               <p>
                 Make the TX module send telemetry data to the handset at a fixed
-                interval. This reduces the "Telemetry Lost" warnings when
-                running at a high telemetry ratio, or low rates like 50hz.
+                interval. This reduces the &quot;Telemetry Lost&quot; warnings
+                when running at a high telemetry ratio, or low rates like 50hz.
               </p>
               <p>
                 Default value is <strong>240LU</strong>. If you want to change

--- a/src/ui/components/UserDefineDescription/index.tsx
+++ b/src/ui/components/UserDefineDescription/index.tsx
@@ -190,8 +190,8 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> =
                 RX by connecting to its wifi network and visiting 10.0.0.1
               </p>
               <p>
-                Wifi internal is defined in <strong>seconds</strong>. Default is
-                20 seconds.
+                Auto on interval is defined in <strong>seconds</strong>. Default
+                is 60 seconds.
               </p>
               <p>
                 <DocumentationLink
@@ -424,19 +424,19 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> =
           return (
             <div>
               <p>
-                It makes the TX module send the telemetry data to the OpenTX
-                every 320 ms by default. This stops the telemetry lost warnings
-                when running a high telemetry ratio, or low rates like 50hz.
+                Make the TX module send telemetry data to the handset at a fixed
+                interval. This reduces the "Telemetry Lost" warnings when
+                running at a high telemetry ratio, or low rates like 50hz.
               </p>
               <p>
-                Default value is <strong>320LU</strong>. If you want to change
+                Default value is <strong>240LU</strong>. If you want to change
                 that you have to suffix your milliseconds value with{' '}
                 <strong>LU</strong>. For example, in order to specify 100 ms
                 telemetry update rate you have to enter it like this:{' '}
                 <strong>100LU</strong>.
               </p>
               <p>
-                Typically, you want to keep <strong>320LU</strong> value for
+                Typically, you want to keep <strong>240LU</strong> value for
                 OpenTX based radios, and <strong>100LU</strong> for ErskyTx
                 ones.
               </p>


### PR DESCRIPTION
- AUTO_WIFI_ON_INTERVAL was actually 30 in v1, and 60 as of v2 onwards 
- TLM_REPORT_INTERVAL_MS was 320LU in v2, and is now 240LU as of v3.

Also some minor rephrasing of these descrptions.
None of the other commonly shown defines after
looking at a few random TX/RX combos stood out
as needing any changes.