### PR TITLE
Detect if we're in a flatpak and correctly list serial devices

### DIFF
--- a/src/api/src/flatpak.ts
+++ b/src/api/src/flatpak.ts
@@ -1,0 +1,100 @@
+import fs, { ReadStream } from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { PortInfo } from '@serialport/bindings-cpp';
+
+const flatpakInfoPath = '/.flatpak-info';
+
+function insideFlatpak() {
+  return process.platform === 'linux' && fs.existsSync(flatpakInfoPath);
+}
+
+function createReadStreamSafe(
+  filename: string,
+  options?: { encoding?: BufferEncoding; autoClose?: boolean }
+): Promise<ReadStream> {
+  return new Promise((resolve, reject) => {
+    const fileStream = fs.createReadStream(filename, options);
+    fileStream.on('error', reject).on('open', () => {
+      resolve(fileStream);
+    });
+  });
+}
+
+const ttySysClassPath = '/sys/class/tty';
+const productRegex = /^PRODUCT=(?<vendorId>\d+)\/(?<productId>\d+)\/.*/;
+
+function listPorts(): Promise<PortInfo[]> {
+  // eslint-disable-next-line no-async-promise-executor
+  return new Promise(async (resolve, reject) => {
+    const ports: PortInfo[] = [];
+    let openedDir;
+    try {
+      openedDir = await fs.promises.opendir(ttySysClassPath);
+    } catch (err) {
+      console.error(err);
+      reject(err);
+    }
+
+    if (!openedDir) {
+      return;
+    }
+
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const fileDirent of openedDir) {
+      const dir = fileDirent.name;
+      const dirPath = path.join(ttySysClassPath, dir);
+
+      const ueventPath = path.join(dirPath, 'device', 'uevent');
+      const ueventPathExists = fs.existsSync(ueventPath);
+
+      if (ueventPathExists) {
+        let port: PortInfo = {
+          path: path.join('/dev', dir),
+          vendorId: undefined,
+          productId: undefined,
+          locationId: undefined,
+          serialNumber: undefined,
+          manufacturer: undefined,
+          pnpId: undefined,
+        };
+
+        const ueventStream = await createReadStreamSafe(ueventPath, {
+          encoding: 'utf8',
+          autoClose: true,
+        });
+        const rl = readline.createInterface({
+          input: ueventStream,
+        });
+        rl.on('line', (line) => {
+          const match = productRegex.exec(line);
+          if (match) {
+            port = {
+              path: path.join('/dev', dir),
+              vendorId: match?.groups?.vendorId.padStart(4, '0'),
+              productId: match?.groups?.productId,
+              locationId: undefined,
+              serialNumber: undefined,
+              manufacturer: undefined,
+              pnpId: undefined,
+            };
+          }
+        });
+        rl.on('close', () => {
+          if (port) {
+            ports.push(port);
+          }
+        });
+      }
+    }
+
+    const collator = new Intl.Collator([], { numeric: true });
+    ports.sort((a, b) => {
+      return collator.compare(a.path, b.path);
+    });
+
+    resolve(ports);
+  });
+}
+
+export { insideFlatpak, listPorts };

--- a/src/api/src/services/SerialMonitor/index.ts
+++ b/src/api/src/services/SerialMonitor/index.ts
@@ -5,6 +5,7 @@ import SerialPortInformation from '../../models/SerialPortInformation';
 import PubSubTopic from '../../pubsub/enum/PubSubTopic';
 import { LoggerService } from '../../logger';
 import SerialMonitorEventType from '../../models/enum/SerialMonitorEventType';
+import { insideFlatpak, listPorts } from '../../flatpak';
 
 export interface SerialMonitorLogUpdatePayload {
   data: string;
@@ -41,7 +42,12 @@ export default class SerialMonitorService {
   }
 
   async getAvailableDevices(): Promise<SerialPortInformation[]> {
-    const list = await SerialPort.list();
+    let list;
+    if (insideFlatpak()) {
+      list = await listPorts();
+    } else {
+      list = await SerialPort.list();
+    }
     return list.map(
       (item) => new SerialPortInformation(item.path, item.manufacturer || '')
     );


### PR DESCRIPTION
The only difference in the listing is, that there is no manufacturer listed. Otherwise it seems to work.

Still, flashing from flatpak does not work due to the udev rule it seems.


```
Retrieving maximum program size .pio/build/RadioMaster_Zorro_2400_TX_via_ETX/firmware.elf
Checking size .pio/build/RadioMaster_Zorro_2400_TX_via_ETX/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [==        ]  21.8% (used 71548 bytes from 327680 bytes)
Flash: [=======   ]  73.9% (used 1453805 bytes from 1966080 bytes)
init_passthrough(["upload"], [".pio/build/RadioMaster_Zorro_2400_TX_via_ETX/firmware.bin"])

Warning! Please install `99-platformio-udev.rules`. 
More details: https://docs.platformio.org/en/latest/core/installation/udev-rules.html

Auto-detected: /dev/ttyACM0
======== PASSTHROUGH INIT ========
  Trying to initialize /dev/ttyACM0 @ 460800
*** [upload] ExpectTimeout : 
Traceback (most recent call last):
  File "/home/razze/.platformio/packages/tool-scons/scons-local-4.4.0/SCons/Action.py", line 1318, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "/home/razze/.var/app/com.github.expresslrs.ExpressLRSConfigurator/config/ExpressLRS Configurator/firmwares/github/ExpressLRS/src/python/ETXinitPassthrough.py", line 56, in init_passthrough
    etx_passthrough_init(port, env['UPLOAD_SPEED'])
  File "/home/razze/.var/app/com.github.expresslrs.ExpressLRSConfigurator/config/ExpressLRS Configurator/firmwares/github/ExpressLRS/src/python/ETXinitPassthrough.py", line 24, in etx_passthrough_init
    rl.expect_bytes(b"set: ", timeout=1.0)
  File "/home/razze/.var/app/com.github.expresslrs.ExpressLRSConfigurator/config/ExpressLRS Configurator/firmwares/github/ExpressLRS/src/python/external/streamexpect.py", line 516, in expect_bytes
    return self.expect(BytesSearcher(b), timeout)
  File "/home/razze/.var/app/com.github.expresslrs.ExpressLRSConfigurator/config/ExpressLRS Configurator/firmwares/github/ExpressLRS/src/python/external/streamexpect.py", line 666, in expect
    incoming = self._stream_adapter.poll(end - time.time())
  File "/home/razze/.var/app/com.github.expresslrs.ExpressLRSConfigurator/config/ExpressLRS Configurator/firmwares/github/ExpressLRS/src/python/external/streamexpect.py", line 455, in poll
    raise ExpectTimeout()
external.streamexpect.ExpectTimeout
========================= [FAILED] Took 30.63 seconds =========================
Environment                        Status    Duration
---------------------------------  --------  ------------
RadioMaster_Zorro_2400_TX_via_ETX  FAILED    00:00:30.633
==================== 1 failed, 0 succeeded in 00:00:30.633 ====================
```

ref https://github.com/ExpressLRS/ExpressLRS-Configurator/issues/390