### PR TITLE
Add EMAX nano TX targets

### DIFF
--- a/devices/emax-2400.json
+++ b/devices/emax-2400.json
@@ -16,20 +16,38 @@
       "REGULATORY_DOMAIN_ISM_2400",
       "REGULATORY_DOMAIN_EU_CE_2400",
       "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
       "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
       "UART_INVERTED",
       "AUTO_WIFI_ON_INTERVAL",
       "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB"
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "EMAX 2.4 GHz",
+    "name": "EMAX Nano 2.4GHz TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "EMAX_NANO_2400_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "EMAX_NANO_2400_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_ISM_2400",
+      "REGULATORY_DOMAIN_EU_CE_2400",
+      "BINDING_PHRASE",
+      "TLM_REPORT_INTERVAL_MS",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
     ],
     "wikiUrl": "",
     "deviceType": "ExpressLRS",

--- a/devices/emax-900.json
+++ b/devices/emax-900.json
@@ -18,16 +18,40 @@
       "REGULATORY_DOMAIN_FCC_915",
       "REGULATORY_DOMAIN_IN_866",
       "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "ARM_CHANNEL",
-      "LOCK_ON_FIRST_CONNECTION",
-      "AUTO_WIFI_ON_BOOT",
+      "TLM_REPORT_INTERVAL_MS",
+      "UART_INVERTED",
       "AUTO_WIFI_ON_INTERVAL",
       "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "RCVR_UART_BAUD",
-      "RCVR_INVERT_TX"
+      "HOME_WIFI_PASSWORD"
+    ],
+    "wikiUrl": "",
+    "deviceType": "ExpressLRS",
+    "aliases": []
+  },
+  {
+    "category": "EMAX 900 MHz",
+    "name": "EMAX Nano 900MHz TX",
+    "targets": [
+      {
+        "flashingMethod": "UART",
+        "name": "EMAX_NANO_900_TX_via_UART"
+      },
+      {
+        "flashingMethod": "WIFI",
+        "name": "EMAX_NANO_900_TX_via_WIFI"
+      }
+    ],
+    "userDefines": [
+      "REGULATORY_DOMAIN_AU_915",
+      "REGULATORY_DOMAIN_EU_868",
+      "REGULATORY_DOMAIN_FCC_915",
+      "REGULATORY_DOMAIN_IN_866",
+      "BINDING_PHRASE",
+      "TLM_REPORT_INTERVAL_MS",
+      "UART_INVERTED",
+      "AUTO_WIFI_ON_INTERVAL",
+      "HOME_WIFI_SSID",
+      "HOME_WIFI_PASSWORD"
     ],
     "wikiUrl": "",
     "deviceType": "ExpressLRS",


### PR DESCRIPTION
With adjustments to previous targets as they were introduced in 3.0 so some options didn't make sense