### PR TITLE
Fix faq link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you don't have the time to contribute in that way, consider making a small do
 [![Open Collective backers](https://img.shields.io/opencollective/backers/expresslrs?label=Open%20Collective%20backers)](https://opencollective.com/expresslrs)
 
 ## Quick Start Guide
-If you have hardware that you want to flash, please refer to our guides on the [website](https://www.expresslrs.org/), and our [FAQ](https://www.expresslrs.org/faq/)
+If you have hardware that you want to flash, please refer to our guides on the [website](https://www.expresslrs.org/), and our [FAQ](https://www.expresslrs.org/3.0/faq/)
 
 ## Installation
 


### PR DESCRIPTION
The old link is not working, it might be nicer to have something like latest or redirect the url to latest instead.