### PR TITLE
The slim pro should be just an alias

### DIFF
--- a/devices/happymodel-2400.json
+++ b/devices/happymodel-2400.json
@@ -37,42 +37,6 @@
   },
   {
     "category": "Happymodel 2.4 GHz",
-    "name": "HappyModel ES24TX Slim Pro 2400 TX",
-    "targets": [
-      {
-        "flashingMethod": "UART",
-        "name": "HappyModel_ES24TX_Slim_Pro_2400_TX_via_UART"
-      },
-      {
-        "flashingMethod": "WIFI",
-        "name": "HappyModel_ES24TX_Slim_Pro_2400_TX_via_WIFI"
-      }
-    ],
-    "userDefines": [
-      "REGULATORY_DOMAIN_ISM_2400",
-      "REGULATORY_DOMAIN_EU_CE_2400",
-      "BINDING_PHRASE",
-      "HYBRID_SWITCHES_8",
-      "ENABLE_TELEMETRY",
-      "TLM_REPORT_INTERVAL_MS",
-      "NO_SYNC_ON_ARM",
-      "ARM_CHANNEL",
-      "FEATURE_OPENTX_SYNC",
-      "USE_500HZ",
-      "UART_INVERTED",
-      "AUTO_WIFI_ON_INTERVAL",
-      "HOME_WIFI_SSID",
-      "HOME_WIFI_PASSWORD",
-      "BLE_HID_JOYSTICK",
-      "USE_DYNAMIC_POWER",
-      "WS2812_IS_GRB"
-    ],
-    "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/es24tx/",
-    "deviceType": "ExpressLRS",
-    "aliases": []
-  },
-  {
-    "category": "Happymodel 2.4 GHz",
     "name": "HM ES24TX Pro Series 2400 TX",
     "targets": [
       {
@@ -105,7 +69,14 @@
     ],
     "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/es24tx/",
     "deviceType": "ExpressLRS",
-    "aliases": []
+    "aliases": [
+      {
+        "category": "Happymodel 2.4 GHz",
+        "name": "HappyModel ES24TX Slim Pro 2400 TX",
+        "wikiUrl": "",
+        "abbreviatedName": "HM ES24 SlimPro"
+      }
+    ]
   },
   {
     "category": "Happymodel 2.4 GHz",


### PR DESCRIPTION
The HappyModel Slim Pro module has been broken for some time as it's actually just an alias for the regular pro series one and the firmware repo didn't actually have a target called `HappyModel_ES24TX_Slim_Pro_2400_TX_via_*`