### PR TITLE
Fix React.Strict and Apollo polling issue

### DIFF
--- a/src/ui/components/SerialConnectionForm/index.tsx
+++ b/src/ui/components/SerialConnectionForm/index.tsx
@@ -32,9 +32,16 @@ const SerialConnectionForm: FunctionComponent<SerialConnectionFormProps> = (
 ) => {
   const { onConnect, serialDevice, baudRate } = props;
 
-  const { loading, data, error, previousData } = useAvailableDevicesListQuery({
-    pollInterval: 1000,
-  });
+  const { loading, data, error, previousData, startPolling, stopPolling } =
+    useAvailableDevicesListQuery();
+
+  useEffect(() => {
+    startPolling(1000);
+    return () => {
+      stopPolling();
+    };
+  }, [startPolling, stopPolling]);
+
   const options: Option[] =
     data?.availableDevicesList?.map((target) => ({
       label: `${target.path} ${target.manufacturer}`,

--- a/src/ui/components/SerialDeviceSelect/index.tsx
+++ b/src/ui/components/SerialDeviceSelect/index.tsx
@@ -42,9 +42,16 @@ const SerialDeviceSelect: FunctionComponent<SerialDeviceSelectProps> = (
 ) => {
   const { serialDevice, onChange } = props;
 
-  const { loading, data, error, previousData } = useAvailableDevicesListQuery({
-    pollInterval: 1000,
-  });
+  const { loading, data, error, previousData, startPolling, stopPolling } =
+    useAvailableDevicesListQuery();
+
+  useEffect(() => {
+    startPolling(1000);
+    return () => {
+      stopPolling();
+    };
+  }, [startPolling, stopPolling]);
+
   const options: Option[] =
     data?.availableDevicesList?.map((target) => ({
       label: `${target.path} ${target.manufacturer}`,


### PR DESCRIPTION
When React.Strict is specified, Apollo polling does not automatically start when a pollInterval is specified, startPolling must be explicitly called.

See issue https://github.com/apollographql/apollo-client/issues/9819