### PR TITLE
use Pro Series for both Slim Pro and full size Pro

### DIFF
--- a/devices/happymodel-2400.json
+++ b/devices/happymodel-2400.json
@@ -69,14 +69,7 @@
     ],
     "wikiUrl": "https://www.expresslrs.org/{version}/quick-start/transmitters/es24tx/",
     "deviceType": "ExpressLRS",
-    "aliases": [
-      {
-        "category": "Happymodel 2.4 GHz",
-        "name": "HappyModel ES24TX Slim Pro 2400 TX",
-        "wikiUrl": "",
-        "abbreviatedName": "HM ES24 SlimPro"
-      }
-    ]
+    "aliases": []
   },
   {
     "category": "Happymodel 2.4 GHz",


### PR DESCRIPTION
The only reason I see it's there is for the abbreviatedName

we either call the main one specific for the full-size Pro (like HappyModel ES24TX Pro 2400 TX), change the Lua Name, etc
or
this approach.