### PR TITLE
Add support for using semantic versioning comparators to exclude version ranges

### DIFF
--- a/src/ui/components/FirmwareVersionForm/index.tsx
+++ b/src/ui/components/FirmwareVersionForm/index.tsx
@@ -129,9 +129,17 @@ const FirmwareVersionForm: FunctionComponent<FirmwareVersionCardProps> = (
 
   const gitTags = useMemo(() => {
     return (
-      gitTagsResponse?.releases.filter(
-        ({ tagName }) => !gitRepository.tagExcludes.includes(tagName)
-      ) ?? []
+      gitTagsResponse?.releases.filter(({ tagName }) => {
+        for (let i = 0; i < gitRepository.tagExcludes.length; i++) {
+          const tagExclude = gitRepository.tagExcludes[i];
+          if (
+            semver.satisfies(tagName, tagExclude, { includePrerelease: true })
+          ) {
+            return false;
+          }
+        }
+        return true;
+      }) ?? []
     ).sort((a, b) => semver.rcompare(a.tagName, b.tagName));
   }, [gitRepository.tagExcludes, gitTagsResponse?.releases]);
 

--- a/src/ui/config/index.ts
+++ b/src/ui/config/index.ts
@@ -23,7 +23,7 @@ export const Config: IConfig = {
     repositoryName: 'ExpressLRS',
     rawRepoUrl: 'https://raw.githubusercontent.com/ExpressLRS/ExpressLRS',
     srcFolder: 'src',
-    tagExcludes: ['1.0.0-RC1', '1.0.0-RC2', '1.0.0-RC3'],
+    tagExcludes: ['<2.5.0'],
   },
   backpackGit: {
     cloneUrl: 'https://github.com/ExpressLRS/Backpack',


### PR DESCRIPTION
Currently the tag excludes only supports specifically listing the version that should be excluded from the list, this adds supports for using semantic versioning comparators.   For instance, if it is desired to exclude all versions prior to 2.5.0, this change allows it to be done by specifying "<2.5.0" instead of listing each version individually. 