### PR TITLE
Categorize HDZero Goggle VRX Backpack as "Goggles"

### DIFF
--- a/devices/hdzero-backpack.json
+++ b/devices/hdzero-backpack.json
@@ -22,7 +22,7 @@
     "aliases": []
   },
   {
-    "category": "VRX",
+    "category": "Goggles",
     "name": "HDZero Goggle VRX Backpack",
     "targets": [
       {


### PR DESCRIPTION
With there already being a category for `Goggles` (containing the [`Orqa FPV.Connect ESP Backpack`](https://github.com/ExpressLRS/ExpressLRS-Configurator/blob/master/devices/orqa-backpack.json#L3)) this target should be moved there as well.