### PR TITLE
Adds Happymodel EPW5 and EPW6 targets

### DIFF
--- a/devices/diy-2400.json
+++ b/devices/diy-2400.json
@@ -354,6 +354,12 @@
         "name": "RadioMaster ER5A/C 2.4GHz PWM RX",
         "wikiUrl": "",
         "abbreviatedName": "RM ER5A/C 2G4RX"
+      },
+      {
+        "category": "Happymodel 2.4 GHz",
+        "name": "Happymodel EPW5 2.4GHz PWM RX",
+        "wikiUrl": "",
+        "abbreviatedName": "HM EPW5 2G4RX"
       }
     ]
   },
@@ -381,7 +387,14 @@
     ],
     "wikiUrl": "https://www.expresslrs.org/quick-start/receivers/diy2400/",
     "deviceType": "ExpressLRS",
-    "aliases": []
+    "aliases": [
+      {
+        "category": "Happymodel 2.4 GHz",
+        "name": "Happymodel EPW6 2.4GHz PWM RX",
+        "wikiUrl": "",
+        "abbreviatedName": "HM EPW6 2G4RX"
+      }
+    ]
   },
   {
     "category": "DIY 2.4 GHz",


### PR DESCRIPTION
https://www.happymodel.cn/index.php/2021/12/29/happymodel-expresslrs-elrs-epw5-2-4ghz-5ch-pwm-rc-receiver-for-fixed-wing/

https://www.happymodel.cn/index.php/2023/01/10/happymodel-expresslrs-elrs-epw6-tcxo-2-4ghz-6ch-pwm-rc-receiver-for-fixed-wing-epw5-2-4ghz-replacement/