### PR TITLE
Add Matek R24-P6

### DIFF
--- a/devices/diy-2400.json
+++ b/devices/diy-2400.json
@@ -399,6 +399,12 @@
         "name": "Happymodel EPW6 2.4GHz PWM RX",
         "wikiUrl": "",
         "abbreviatedName": "HM EPW6 2G4RX"
+      },
+      {
+        "category": "Matek 2.4 GHz",
+        "name": "Matek R24-P6 PWM 2.4GHz RX",
+        "wikiUrl": "",
+        "abbreviatedName": "Matek R24-P6"
       }
     ]
   },


### PR DESCRIPTION
Adds a Matek 6ch PWM RX (using DIY PWMPEX target)

https://github.com/ExpressLRS/ExpressLRS/pull/2193