### PR TITLE
Rename HappyModel EP to EP1/2

### DIFF
--- a/devices/happymodel-2400.json
+++ b/devices/happymodel-2400.json
@@ -73,7 +73,7 @@
   },
   {
     "category": "Happymodel 2.4 GHz",
-    "name": "HappyModel EP 2400 RX",
+    "name": "HappyModel EP1/2 2400 RX",
     "targets": [
       {
         "flashingMethod": "UART",


### PR DESCRIPTION
I had someone ask me what target to use for their EP2 receiver and said they couldn't find it in the configurator. This renames "HappyModel EP 2400 RX" to "HappyModel EP1/2 2400 RX" to help with identification and match what is in the ELRS targets.json. It also could help someone with an "EP1 Dual" who might think "EP" is close enough? Probably not?