### PR TITLE
When filtering the Wifi device selection list, examine the lua name as well as the prior target name.

### DIFF
--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -893,9 +893,17 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
                     wifiDevice={wifiDevice}
                     wifiDevices={Array.from(networkDevices.values()).filter(
                       (item) => {
-                        return deviceTarget?.name
-                          ?.toUpperCase()
-                          .startsWith(item.target.toUpperCase());
+                        return (
+                          deviceTarget?.name
+                            ?.toUpperCase()
+                            .startsWith(item.target.toUpperCase()) ||
+                          device?.luaName?.toUpperCase() ===
+                            item.deviceName.toUpperCase() ||
+                          (device?.priorTargetName &&
+                            item.target
+                              .toUpperCase()
+                              .startsWith(device.priorTargetName.toUpperCase()))
+                        );
                       }
                     )}
                     onChange={onWifiDevice}


### PR DESCRIPTION

Closes #515 