### PR TITLE
Check if the read config is valid before setting type and frequency

### DIFF
--- a/src/api/src/services/BinaryFlashingStrategy/TargetsJSONLoader/index.ts
+++ b/src/api/src/services/BinaryFlashingStrategy/TargetsJSONLoader/index.ts
@@ -64,20 +64,20 @@ export class TargetsJSONLoader {
           const id = `${categoryKey}.${subTypeKey}.${deviceDescriptionKey}`;
           const config = configs[deviceDescriptionKey];
 
-          const [type, frequency] = subTypeKey.split('_');
-          config.type = type.toUpperCase();
-          const frequencyNumber = parseInt(frequency, 10);
-
-          let category = categoryName;
-
-          if (frequencyNumber) {
-            config.frequency = frequencyNumber;
-            category = `${categoryName} ${this.frequencyFormatter(
-              config.frequency
-            )}`;
-          }
-
           if (this.validConfig(id, config)) {
+            const [type, frequency] = subTypeKey.split('_');
+            config.type = type.toUpperCase();
+            const frequencyNumber = parseInt(frequency, 10);
+
+            let category = categoryName;
+
+            if (frequencyNumber) {
+              config.frequency = frequencyNumber;
+              category = `${categoryName} ${this.frequencyFormatter(
+                config.frequency
+              )}`;
+            }
+
             result[id] = {
               category,
               config,


### PR DESCRIPTION
On version 3.0.1 and 3.0.0 there are some invalid config entries, check if the config object is valid before trying to set the type and frequency on the object.

![image](https://github.com/ExpressLRS/ExpressLRS-Configurator/assets/38869875/ecdac8ce-e79b-4257-a5a3-2e0e3440c3cb)
