### PR TITLE
Fix error after flashing

### DIFF
--- a/src/api/src/services/BinaryFlashingStrategy/index.ts
+++ b/src/api/src/services/BinaryFlashingStrategy/index.ts
@@ -605,10 +605,7 @@ export default class BinaryFlashingStrategyService implements FlashingStrategy {
         );
       }
 
-      if (
-        params.type === BuildJobType.BuildAndFlash ||
-        params.type === BuildJobType.ForceFlash
-      ) {
+      if (params.type === BuildJobType.Flash) {
         return new BuildFlashFirmwareResult(true, '');
       }
 


### PR DESCRIPTION
Statement was checking for non-existent `BuildJobType` which caused an exception and so an error was displayed after a successful flash