### PR TITLE
Fix issue with Auto Updater and I18n

### DIFF
--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -157,11 +157,11 @@
     "Sure": "Sure",
     "Later": "Later",
     "UpdateDownloading": "Update Downloading",
-    "NotifiedWhenReadyToInstall.": "Update is being downloaded, you will be notified when it is ready to install.",
+    "NotifiedWhenReadyToInstall": "Update is being downloaded, you will be notified when it is ready to install.",
     "Restart": "Restart",
     "ApplicationUpdate": "Application Update",
     "Update": "Update",
-    "ApplyUpdates.": "A new version has been downloaded. Restart the application to apply the updates."
+    "ApplyUpdates": "A new version has been downloaded. Restart the application to apply the updates."
   },
   "ConfiguratorView": {
     "DownloadLUAScript": "Download LUA script",

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -411,7 +411,7 @@ const createWindow = async () => {
     shell.openExternal(url);
   });
 
-  updater = new Updater(logger, mainWindow);
+  updater = new Updater(logger, mainWindow, baseUrl);
 };
 /**
  * Add event listeners...


### PR DESCRIPTION
useTranslation() can not be used in the auto updater because it is called by the main process and is not part of the browser UI window.  Instead, initiate its own version of i18next using the system locale as the preferred language.

2 keys in the English messages.json were also corrected, they had an extraneous period at the end.  This change will affect the translations on crowdin since the key has changed.