### PR TITLE
Update gitignore to include windows release files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,9 @@ node_modules
 /release/linux-*
 /release/win-*
 /release/mac-*
-/release/expresslrs-configurator*
+/release/expresslrs[ -]configurator*
 /release/builder-*
-/release/latest-*
+/release/latest[/.-]*
 /src/dist
 /.erb/dll
 


### PR DESCRIPTION
Update gitignore to include windows release files like ExpressLRS Configurator Setup.exe and latest.yml