### PR TITLE
Sort languages list alphabetically in settings screen

### DIFF
--- a/src/ui/views/SettingsView/index.tsx
+++ b/src/ui/views/SettingsView/index.tsx
@@ -19,8 +19,8 @@ import useDeveloperMode from '../../hooks/useDeveloperMode';
 const SettingsView: FunctionComponent = () => {
   const { t, i18n } = useTranslation();
 
-  // Sort language labels in "()" alphabetically except English, becaunse English has no "()".
-  const languages = [...locales].sort((a, b) => {
+  // Sort language labels in "()" alphabetically except English, because English has no "()".
+  const languages: Option[] = [...locales].sort((a, b) => {
     const labelA =
       a.label.match(/\(([^)]+)\)/)?.[1].toLowerCase() || a.label.toLowerCase();
     const labelB =

--- a/src/ui/views/SettingsView/index.tsx
+++ b/src/ui/views/SettingsView/index.tsx
@@ -18,8 +18,18 @@ import useDeveloperMode from '../../hooks/useDeveloperMode';
 
 const SettingsView: FunctionComponent = () => {
   const { t, i18n } = useTranslation();
-  const languages: Option[] = locales;
-  const defaultLanguage = locales[0];
+
+  // Sort language labels in "()" alphabetically except English, becaunse English has no "()".
+  const languages = [...locales].sort((a, b) => {
+    const labelA =
+      a.label.match(/\(([^)]+)\)/)?.[1].toLowerCase() || a.label.toLowerCase();
+    const labelB =
+      b.label.match(/\(([^)]+)\)/)?.[1].toLowerCase() || b.label.toLowerCase();
+    return labelA.localeCompare(labelB);
+  });
+
+  const defaultLanguage = languages[0];
+
   const onLocaleChange = (locale: string | null) => {
     if (locale === null) {
       i18n.changeLanguage(defaultLanguage.value);


### PR DESCRIPTION
Try to solve #604 
Sort language labels in "()" alphabetically except English, becaunse English has no "()" in locale json file.
![image](https://github.com/ExpressLRS/ExpressLRS-Configurator/assets/33802186/ba99ea05-2ad6-481e-bae1-c62774c6b0d2)
