### PR TITLE
use local targetsdata for local builds, fixes #580

### DIFF
--- a/src/api/src/services/BinaryFlashingStrategy/DeviceDescriptionsLoader/index.ts
+++ b/src/api/src/services/BinaryFlashingStrategy/DeviceDescriptionsLoader/index.ts
@@ -1,6 +1,7 @@
 import extractZip from 'extract-zip';
 import { Service } from 'typedi';
 import path from 'path';
+import { existsSync } from 'fs';
 import { mkdirp } from 'mkdirp';
 import semver from 'semver';
 import FirmwareSource from '../../../models/enum/FirmwareSource';
@@ -163,6 +164,13 @@ export default class DeviceDescriptionsLoader {
     this.logger?.log('git path', {
       gitPath,
     });
+
+    if (
+      args.source === FirmwareSource.Local &&
+      existsSync(path.join(args.localPath, 'hardware'))
+    ) {
+      return path.join(args.localPath, 'hardware');
+    }
 
     if (gitRepository.hardwareArtifactUrl) {
       const workingDir = path.join(gitRepositoryPath, 'hardware');


### PR DESCRIPTION
Seems like during the transition to the separate targets repo we have lost the ability to load target definitions from a local repository. i always found that quite handy for messing around with diy hardware. 

This PR restores that functionality by checking if a local repo actually has the hardware folder present and the only then returning the local path. 