### PR TITLE
Fix broken LoRaWAN Link

### DIFF
--- a/src/ui/components/UserDefineDescription/index.tsx
+++ b/src/ui/components/UserDefineDescription/index.tsx
@@ -39,7 +39,7 @@ const UserDefineDescription: FunctionComponent<UserDefineDescriptionProps> =
                   i18nKey="UserDefineDescription.RegulatoryDomain915"
                   components={{
                     LoRaWANLink: (
-                      <DocumentationLink url="https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country.html" />
+                      <DocumentationLink url="https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country/" />
                     ),
                   }}
                 />


### PR DESCRIPTION
https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country.html 404s. Correct link is https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country/