### PR TITLE
improve `RxAsTx` description text

### DIFF
--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -123,7 +123,7 @@
     "UseR9MMR9MiniSBUS": "<p><strong>THIS DOES NOT ENABLE SBUS PROTOCOL.</strong></p><p>This is useful for F4 FCs which do not have an uninverted UART option. This is only one way, so you lose the telemetry downlink to your radio as well as passthrough flashing. This will output out of the default S.BUS pin on your R9MM/R9Mini. Set serialrx_inverted = ON may also be needed within Betaflight for compatibility</p>",
     "HomeWifiSSID": "Set home Wi-Fi network name (SSID). It will allow Wi-Fi enabled hardware to connect to the home network automatically.",
     "HomeWifiPassword": "Set home Wi-Fi network password. It will allow Wi-Fi enabled hardware to connect to the home network automatically.",
-    "RxAsTx": "Flash your receiver with this option enabled and use it instead of your TX module."
+    "RxAsTx": "Flash your receiver with this option enabled and use it as a TX module."
   },
   "UserDefinesAdvisor": {
     "DisableUARTInvertedWarning": "Disabling UART_INVERTED is uncommon. Please make sure that your transmitter supports that."


### PR DESCRIPTION
"Flash your receiver with this option enabled and use it as a  ~~instead of your~~ TX module."