### PR TITLE
Some user defines should be available in expert mode only

### DIFF
--- a/src/ui/components/DeviceOptionsForm/index.tsx
+++ b/src/ui/components/DeviceOptionsForm/index.tsx
@@ -76,8 +76,26 @@ export type UserDefinesKeysByCategory = {
   [key in UserDefineCategory]: UserDefineKey[];
 };
 
+const EXPERT_MODE_USER_DEFINES: UserDefineKey[] = [
+  UserDefineKey.RX_AS_TX,
+  UserDefineKey.LOCK_ON_FIRST_CONNECTION,
+  UserDefineKey.MY_STARTUP_MELODY,
+  UserDefineKey.AUTO_WIFI_ON_INTERVAL,
+  UserDefineKey.DISABLE_ALL_BEEPS,
+  UserDefineKey.DISABLE_STARTUP_BEEP,
+  UserDefineKey.DEVICE_NAME,
+  UserDefineKey.RCVR_INVERT_TX,
+  UserDefineKey.RCVR_UART_BAUD,
+  UserDefineKey.RX_AS_TX,
+  UserDefineKey.TLM_REPORT_INTERVAL_MS,
+  UserDefineKey.UART_INVERTED,
+  UserDefineKey.UNLOCK_HIGHER_POWER,
+  UserDefineKey.USE_R9MM_R9MINI_SBUS,
+];
+
 const userDefinesToCategories = (
-  userDefines: UserDefine[]
+  userDefines: UserDefine[],
+  isExpertModeEnabled: boolean
 ): UserDefinesByCategory => {
   const result: UserDefinesByCategory = {
     [UserDefineCategory.RegulatoryDomainsISM]: [],
@@ -146,7 +164,13 @@ const userDefinesToCategories = (
   };
 
   userDefines.forEach((userDefine) => {
-    result[defineToCategory(userDefine.key)].push(userDefine);
+    if (
+      isExpertModeEnabled ||
+      (!isExpertModeEnabled &&
+        !EXPERT_MODE_USER_DEFINES.includes(userDefine.key))
+    ) {
+      result[defineToCategory(userDefine.key)].push(userDefine);
+    }
   });
 
   return result;
@@ -166,7 +190,11 @@ const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
   props
 ) => {
   const { target, deviceOptions, onChange } = props;
-  const categories = userDefinesToCategories(deviceOptions.userDefineOptions);
+  const { isExpertModeEnabled } = useAppState();
+  const categories = userDefinesToCategories(
+    deviceOptions.userDefineOptions,
+    isExpertModeEnabled
+  );
   const { t } = useTranslation();
 
   const onOptionUpdate = (data: UserDefine) => {
@@ -253,8 +281,6 @@ const DeviceOptionsForm: FunctionComponent<DeviceOptionsFormProps> = (
         console.error(err);
       });
   };
-
-  const { isExpertModeEnabled } = useAppState();
 
   return (
     <>

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -98,7 +98,23 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
   return (
     <List>
       {options.map((item) => {
-        if (!isExpertModeEnabled && item.key === UserDefineKey.RX_AS_TX) {
+        const expertDefines: UserDefineKey[] = [
+          UserDefineKey.RX_AS_TX,
+          UserDefineKey.LOCK_ON_FIRST_CONNECTION,
+          UserDefineKey.MY_STARTUP_MELODY,
+          UserDefineKey.AUTO_WIFI_ON_INTERVAL,
+          UserDefineKey.DISABLE_ALL_BEEPS,
+          UserDefineKey.DISABLE_STARTUP_BEEP,
+          UserDefineKey.DEVICE_NAME,
+          UserDefineKey.RCVR_INVERT_TX,
+          UserDefineKey.RCVR_UART_BAUD,
+          UserDefineKey.RX_AS_TX,
+          UserDefineKey.TLM_REPORT_INTERVAL_MS,
+          UserDefineKey.UART_INVERTED,
+          UserDefineKey.UNLOCK_HIGHER_POWER,
+          UserDefineKey.USE_R9MM_R9MINI_SBUS,
+        ];
+        if (!isExpertModeEnabled && expertDefines.includes(item.key)) {
           return null;
         }
         return (

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -19,7 +19,6 @@ import {
 import Omnibox from '../Omnibox';
 import UserDefineDescription from '../UserDefineDescription';
 import SensitiveTextField from '../SensitiveTextField';
-import useAppState from '../../hooks/useAppState';
 
 const styles: Record<string, SxProps<Theme>> = {
   icon: {
@@ -93,30 +92,9 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
     }
   };
 
-  const { isExpertModeEnabled } = useAppState();
-
   return (
     <List>
       {options.map((item) => {
-        const expertDefines: UserDefineKey[] = [
-          UserDefineKey.RX_AS_TX,
-          UserDefineKey.LOCK_ON_FIRST_CONNECTION,
-          UserDefineKey.MY_STARTUP_MELODY,
-          UserDefineKey.AUTO_WIFI_ON_INTERVAL,
-          UserDefineKey.DISABLE_ALL_BEEPS,
-          UserDefineKey.DISABLE_STARTUP_BEEP,
-          UserDefineKey.DEVICE_NAME,
-          UserDefineKey.RCVR_INVERT_TX,
-          UserDefineKey.RCVR_UART_BAUD,
-          UserDefineKey.RX_AS_TX,
-          UserDefineKey.TLM_REPORT_INTERVAL_MS,
-          UserDefineKey.UART_INVERTED,
-          UserDefineKey.UNLOCK_HIGHER_POWER,
-          UserDefineKey.USE_R9MM_R9MINI_SBUS,
-        ];
-        if (!isExpertModeEnabled && expertDefines.includes(item.key)) {
-          return null;
-        }
         return (
           <React.Fragment key={item.key}>
             <ListItem

--- a/src/ui/storage/index.ts
+++ b/src/ui/storage/index.ts
@@ -84,7 +84,11 @@ export default class ApplicationStorage implements IApplicationStorage {
   }
 
   async getDeviceOptions(device: string): Promise<DeviceOptions | null> {
-    const key = `${DEVICE_OPTIONS_BY_TARGET_KEYSPACE}.${device}`;
+    const isExpertModeEnabled = this.getExpertModeEnabled();
+    // in order to preserve backwards compatibility of device options we add a
+    // keyspace modifier to separate non experd mode device options
+    const expertStr = isExpertModeEnabled ? '' : '.non_expert_mode';
+    const key = `${DEVICE_OPTIONS_BY_TARGET_KEYSPACE}.${device}${expertStr}`;
     const value = localStorage.getItem(key);
     if (value === null) {
       return null;


### PR DESCRIPTION
- [ ] Handle UART_INVERTED warning when expert mode is off
- [ ] When expert mode is off, "expert mode" only user defines should retain their safe default values