### PR TITLE
Fix local builds unable to flash custom targets

### DIFF
--- a/src/api/src/services/BinaryFlashingStrategy/index.ts
+++ b/src/api/src/services/BinaryFlashingStrategy/index.ts
@@ -562,7 +562,10 @@ export default class BinaryFlashingStrategyService implements FlashingStrategy {
       let flasherArgs: string[][];
       if (
         gitRepository.hardwareArtifactUrl &&
-        params.firmware.source !== FirmwareSource.Local
+        !(
+          params.firmware.source === FirmwareSource.Local &&
+          fs.existsSync(path.join(firmwareDescriptionsPath, 'hardware'))
+        )
       ) {
         flasherArgs = this.binaryConfigurator.buildBinaryConfigFlags(
           outputDirectory,


### PR DESCRIPTION
When building firmware from a local repository, the ELRS Configurator looks in that directory for hardware definitions; however, when passing the built firmware to 'binary_configurator.py' it will always set the hardware definition directory (the flag '--dir') to the ELRS Configurator's local data directory. This means that while the build step works, the flash step fails unexpectedly due to the inconsistent hardware definition files.

This change will only affect local builds and only if a hardware directory exists in the local firmware directory. The purpose of the change is to allow custom targets to work with the ELRS Configurator without needing to upstream new targets to the hardware git repository; therefore, this change is only meant for development/advanced users.