### PR TITLE
adding arm builds for macOS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           yarn build
-          yarn electron-builder --publish always --x64 --mac
+          yarn electron-builder --publish always --universal --mac
 
       - name: Publish Linux releases
         if: matrix.os == 'ubuntu-22.04'


### PR DESCRIPTION
macOS Tahoe started throwing warnings that x64 binary support was being deprecated.  This PR sets the build type for macOS to 'universal' instead of 'x64' so that "fat" binaries are generated that contain both architectures

This should address https://github.com/ExpressLRS/ExpressLRS-Configurator/issues/769