### PR TITLE
MacOS build system for arm64 and x64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ patch_targets*
 patcher
 
 TODO.md
+dependencies/darwin_arm64/portable-python-*
+
+AGENTS.md
+pr-description.md

--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,6 @@ patcher
 TODO.md
 dependencies/darwin_arm64/portable-python-*
 
+# Opencode configuration
 AGENTS.md
-pr-description.md
+.opencode

--- a/BUILD-MAC.md
+++ b/BUILD-MAC.md
@@ -1,0 +1,199 @@
+# macOS Build Flow (build-mac.sh)
+
+Quick reference for building the ExpressLRS Configurator native app on macOS.
+
+## Prerequisites
+
+- macOS (Intel or Apple Silicon)
+- Node.js and Yarn installed
+
+## Usage
+
+```bash
+./build-mac.sh arm64         # Apple Silicon (M1/M2/M3/etc.)
+./build-mac.sh x86_64        # Intel (x86)
+./build-mac.sh -a            # auto-detect native architecture and build
+./build-mac.sh -h            # show help message
+```
+
+> **Note:** Running the script with no arguments displays the help message. Use `-a` or `--auto` to build for the detected architecture.
+
+## Build Flow Overview
+
+```mermaid
+flowchart TD
+    subgraph buildmac["build-mac.sh"]
+        S1["Step 1: Detect arch"] --> S2["Step 2: Resolve dirs"]
+        S2 --> S3["Step 3: Validate & auto-download"]
+        S3 --> S4["Step 4: Create mac-deps/ symlinks"]
+        S4 --> S5["Step 5: electron-builder"]
+    end
+
+    S5 --> AP["after-pack.js hook"]
+    AP --> App["ExpressLRS Configurator.app"]
+
+    style buildmac fill:#f0f0f0,stroke:#666
+    style AP fill:#fff3cd,stroke:#856404
+    style App fill:#d4edda,stroke:#155724
+```
+
+## Detailed Steps
+
+### Step 1: Architecture Detection
+
+Determines the target architecture from a CLI argument or the `-a`/`--auto` flag. Without any arguments, the script displays a help message. With `-a`, it auto-detects via `uname -m`. Returns `"arm64"` on Apple Silicon and `"x86_64"` on Intel Macs. Common aliases are supported (`intel`, `aarch64`, `"apple-silicon"`).
+
+### Step 2: Toolchain Directory Resolution
+
+Maps the resolved architecture to its corresponding toolchain root and directory names. These variables feed into the symlink creation step below, allowing `package.json` to reference stable paths regardless of architecture.
+
+### Step 3: Dependency Validation (arm64 only)
+
+Checks whether `dependencies/darwin_arm64/portable-python-3.14.6` exists and is non-empty. If missing (e.g., fresh checkout, after cleanup), the build script automatically runs `dependencies/darwin_arm64/download-portable-python.sh` to download and prepare it. A defensive re-check verifies the directory exists after the download; if not, the build fails with a clear error message.
+
+### Step 4: mac-deps/ Symlink Creation
+
+Creates or refreshes the `mac-deps/` directory with symlinks pointing to the correct architecture-specific toolchain directories. These stable paths (`mac-deps/portable-python`, and `mac-deps/portable-git` on x64) are what `package.json` references in its `extraFiles` configuration.
+
+**Why portable-git is in extraFiles for both architectures:** The `extraFiles` config in `package.json` lists both `portable-python` and `portable-git` unconditionally. On arm64, `build-mac.sh` creates an empty `mac-deps/portable-git` placeholder directory so electron-builder doesn't fail. The `after-pack.js` hook then removes this placeholder from the final `.app` — only `portable-python` ends up bundled.
+
+### Step 5: electron-builder Invocation
+
+Runs `yarn install && yarn build` to compile the application, then delegates to `electron-builder --mac --${ARCH}` using `exec` so that Ctrl+C and other signals are forwarded directly (no orphaned processes).
+
+## Architecture-Specific Behavior
+
+| Feature | arm64 (Apple Silicon) | x86_64 (Intel) |
+|---------|----------------------|----------------|
+| Python | `portable-python-3.14.6` (bundled) | `python-portable-darwin-3.8.4` (bundled) |
+| Git | System `/usr/bin/git` — **not bundled** | `git-2.29.2` (bundled) |
+
+## The mac-deps/ Abstraction Layer
+
+The `mac-deps/` directory provides a stable, architecture-independent interface between the build script and electron-builder. Without it, `package.json` would need arch-specific configuration or multiple build targets.
+
+**How it works:**
+
+1. **`build-mac.sh` creates symlinks at build time:**
+   ```
+   mac-deps/portable-python → ../dependencies/darwin_arm64/portable-python-3.14.6  (arm64)
+   mac-deps/portable-python → ../dependencies/darwin_amd64/python-portable-darwin-3.8.4  (x64)
+   mac-deps/portable-git    → ../dependencies/darwin_amd64/git-2.29.2              (x64 only)
+   ```
+
+2. **`package.json` references stable paths:**
+   ```json
+   { "from": "mac-deps/portable-python", "to": "dependencies/portable-python" }
+   ```
+   Electron-builder copies these symlinks into the `.app` at the runtime path `dependencies/portable-python`.
+
+3. **`scripts/after-pack.js` renames to arch-specific names:**
+   ```
+   dependencies/portable-python  →  dependencies/portable-python-arm64  (or x64)
+   dependencies/portable-git     →  dependencies/portable-git-x64       (x64 only)
+   ```
+
+The runtime code (`src/main/main.ts`) then discovers these arch-specific directories to set up the `PATH` environment variable.
+
+## Directory Structure
+
+```
+dependencies/
+├── darwin_arm64/                          # Apple Silicon toolchains
+│   ├── download-portable-python.sh        # Auto-download script (see Step 3)
+│   └── portable-python-3.14.6/            # Bundled into .app as port...-python-arm64
+│       ├── bin/python                     # Standalone Python 3.14.6
+│       ├── bin/pip                        # pip with pyserial + setuptools installed
+│       └── (other Python runtime files)
+│
+├── darwin_amd64/                          # Intel toolchains
+│   ├── git-2.29.2/                        # Bundled into .app as portable-git-x64
+│   └── python-portable-darwin-3.8.4/      # Bundled into .app as port...-python-x64
+│       ├── bin/python
+│       └── (other Python runtime files)
+│
+├── windows_amd64/                         # Windows toolchains (not covered here)
+│   ├── PortableGit/
+│   └── python/
+ │
+└── get-platformio.py                      # PlatformIO installer (bundled into .app)
+
+mac-deps/                                  # Created fresh by build-mac.sh (gitignored)
+├── portable-python → ../dependencies/...  # Symlink (arch-specific at build time)
+└── portable-git → ../dependencies/...     # Symlink (x64 only)
+```
+
+**Inside the built `.app`:**
+
+```
+ExpressLRS Configurator.app/
+└── Contents/
+    ├── dependencies/                      # electron-builder extraFiles go here
+    │   ├── portable-python-arm64/         # Renamed by after-pack.js
+    │   └── portable-python-x64/           # Renamed by after-pack.js
+    │   ├── portable-git-x64/              # Only on x64 builds
+    │  └── get-platformio.py              # Bundled from package.json extraFiles
+```
+
+## Troubleshooting
+
+### Missing portable dependencies on arm64
+
+**Error:** `Error: dependencies/darwin_arm64/portable-python-3.14.6 is still missing after running download script.`
+
+**Fix:** The build script attempts to auto-download, but if it fails (network error, server unavailable), run the download script manually:
+```bash
+cd dependencies/darwin_arm64 && ./download-portable-python.sh
+```
+
+### Stale mac-deps/ directory
+
+**Symptom:** The build fails with `portable-git not found` or similar, even though you just ran the build.
+
+**Cause:** A previous architecture's `mac-deps/` directory may still exist as a real directory instead of symlinks.
+
+**Fix:** `build-mac.sh` handles this automatically by running `rm -rf mac-deps || true` before creating fresh symlinks. No manual intervention needed — just re-run the build script with your target architecture:
+```bash
+./build-mac.sh arm64
+```
+
+### Building the wrong architecture
+
+**Error:** `▶ Building for macOS x86_64` when you expected arm64 on Apple Silicon.
+
+**Cause:** `uname -m` returns the native architecture, but you may be running under Rosetta 2 translation.
+
+**Fix:** Explicitly specify the architecture:
+```bash
+# Force arm64 even if running under Rosetta
+./build-mac.sh arm64
+
+# Force x86_64 on Apple Silicon
+./build-mac.sh x86_64
+
+# Use auto-detection
+./build-mac.sh -a
+```
+
+### Build failures from electron-builder
+
+**Symptom:** Electron-builder exits with an error but no portable-toolchain-related messages.
+
+**Fixes to try:**
+1. Clear the build cache: `rm -rf release/`
+2. Ensure Node.js and Yarn are installed and functional: `node --version && yarn --version`
+3. Run a clean build from scratch: remove `mac-deps/`, then re-run `./build-mac.sh arm64` (or `x86_64`)
+4. Check the full electron-builder log output for dependency or signing errors
+
+### Manually rebuild portable-python (arm64)
+
+To force a re-download of the arm64 Python toolchain:
+```bash
+rm -rf dependencies/darwin_arm64/portable-python-3.14.6
+./build-mac.sh arm64
+```
+
+The build script will detect the missing directory and run `download-portable-python.sh` automatically. If you want to skip the build and only download:
+```bash
+cd dependencies/darwin_arm64 && ./download-portable-python.sh
+```

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -177,7 +177,7 @@ fi
 echo "▶ Running yarn install/build"
 if [ ! -d "node_modules" ]; then
     echo "▶ node_modules missing, running yarn install..."
-    yarn install
+    yarn install --frozen-lockfile
 fi
 yarn build
 

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Build macOS app for x86_64 (Intel) or arm64 (Apple Silicon).
+#
+# Usage:
+#   ./build-mac.sh arm64        → build Apple Silicon (ARM)
+#   ./build-mac.sh x86_64       → build Intel (x86)
+#   ./build-mac.sh -a           → auto-detect architecture and build
+#   ./build-mac.sh -h           → show help
+#
+# How it works:
+#   1. Resolves the correct portable toolchain directories for the target arch.
+#   2. Creates symlinks in mac-deps/ (portable-python always, portable-git on x64 only).
+#   3. Runs electron-builder which bundles mac-deps/ into the .app via extraFiles
+#      in package.json. The after-pack hook then renames them to arch-specific names
+#      (e.g., portable-python-arm64, portable-git-x64).
+#   4. On arm64, no portable-git is bundled — the app uses /usr/bin/git from macOS.
+#   5. On x64, portable-git is bundled and used at runtime from dependencies/.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# ── Help ───────────────────────────────────────────────────────────────────
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options] [arch]
+
+Build macOS app for x86_64 (Intel) or arm64 (Apple Silicon).
+
+Options:
+  -h, --help      Show this help message
+  -a, --auto      Auto-detect architecture
+
+Architectures:
+  arm64, aarch64  Build for Apple Silicon Macs
+  x86_64, intel   Build for Intel Macs
+
+Examples:
+  $(basename "$0") arm64        # build for Apple Silicon
+  $(basename "$0") -a           # auto-detect and build
+  $(basename "$0") x86_64        # build for Intel Macs
+EOF
+}
+
+# ── Parse flags ────────────────────────────────────────────────────────────
+AUTO=false
+ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help) usage; exit 0 ;;
+        -a|--auto) AUTO=true ;;
+        *) ARGS+=("$arg") ;;
+    esac
+done
+
+# Show help if no arguments provided
+if [[ ${#ARGS[@]} -eq 0 && "$AUTO" == "false" ]]; then
+    usage
+    exit 0
+fi
+
+# ── Portable toolchain configuration ───────────────────────────────────────
+# These directories must exist before building. They contain pre-built,
+# self-contained copies of Python and Git with all their shared libraries
+# bundled alongside them (using @loader_path relative paths).
+
+ARM64_DIR="dependencies/darwin_arm64"
+ARM64_PYTHON="portable-python-3.14.6"
+
+X64_DIR="dependencies/darwin_amd64"
+X64_PYTHON="python-portable-darwin-3.8.4"
+X64_GIT="git-2.29.2"
+
+# ── 1. Detect architecture ────────────────────────────────────────────────
+# Use -a/--auto to auto-detect from uname -m, or use the first CLI argument if provided.
+# Auto-detection returns "arm64" on Apple Silicon and "x86_64" on Intel Macs.
+# When -a/--auto is used, any architecture argument is ignored.
+if [[ "$AUTO" == "true" ]]; then ARCH="$(uname -m)"; ARCH_SOURCE="auto-detected"
+else ARCH="${ARGS[0]}"; ARCH_SOURCE="from CLI"; fi
+
+# Normalize common aliases so users can pass "intel", "aarch64", etc.
+case "$ARCH" in
+  x86_64|intel|x86)
+    ARCH="x86_64" ;;
+  arm64|aarch64|"apple-silicon")
+    ARCH="arm64" ;;
+  *)
+    echo "Error: unknown architecture '$ARCH'. Use x86_64 or arm64." >&2
+    echo "Run with -h for usage." >&2
+    exit 1 ;;
+esac
+
+echo "▶ Building for macOS ${ARCH} (${ARCH_SOURCE})"
+
+# ── 2. Resolve source directories ─────────────────────────────────────────
+# Map the resolved arch to the correct toolchain root, Python dir name,
+# and Git dir name. These feed into the symlink creation step below.
+
+case "$ARCH" in
+  x86_64)
+    SRC_DIR=$X64_DIR
+    SRC_PYTHON=$X64_PYTHON
+    SRC_GIT=$X64_GIT
+    ;;
+  arm64)
+    SRC_DIR=$ARM64_DIR
+    SRC_PYTHON=$ARM64_PYTHON
+    ;;
+esac
+
+# ── 3. Ensure arm64 portable dependencies exist ────────────────────────
+# Only arm64 requires this check. x86_64 portable tools (python, git) are
+# pre-bundled in the repo as stable upstream releases. arm64 portable python is
+# custom-built and may not exist on a fresh checkout or after cleanup.
+
+if [[ "$ARCH" == "arm64" ]]; then
+    python_dir="${SRC_DIR}/${ARM64_PYTHON}"
+    if [ ! -d "$python_dir" ] || [ -z "$(ls -A "$python_dir")" ]; then
+        echo "▶ Downloading missing portable dependencies for arm64..." >&2
+        bash "${ARM64_DIR}/download-portable-python.sh" 2>&1 || {
+            echo "Error: download-portable-python.sh failed." >&2
+            exit 1
+        }
+
+        # Verify the download succeeded
+        if [ ! -d "$python_dir" ] || [ -z "$(ls -A "$python_dir")" ]; then
+            echo "Error: $python_dir is still missing after running download script." >&2
+            exit 1
+        fi
+    fi
+fi
+
+# ── 4. Create mac-deps/ symlinks ─────────────────────────────────────────
+# Removes any existing mac-deps (real directory or stale symlinks) and creates
+# fresh symlinks pointing to the correct arch-specific toolchain directories.
+# These stable mac-deps/ paths are what package.json references in extraFiles,
+# so the build script and electron-builder never need arch-specific config.
+# For arm64, a placeholder portable-git directory is created instead of a
+# symlink (since arm64 doesn't bundle git). The after-pack hook removes it.
+
+echo "▶ creating mac-deps symlinks for ${ARCH}"
+# Validate source directories exist before creating symlinks
+if [ ! -d "$SRC_DIR" ]; then
+    echo "Error: source directory '$SRC_DIR' does not exist." >&2
+    exit 1
+fi
+if [ ! -d "${SRC_DIR}/${SRC_PYTHON}" ]; then
+    echo "Error: python directory '${SRC_DIR}/${SRC_PYTHON}' does not exist." >&2
+    exit 1
+fi
+if [[ "$ARCH" != "arm64" ]] && [ ! -d "${SRC_DIR}/${SRC_GIT}" ]; then
+    echo "Error: git directory '${SRC_DIR}/${SRC_GIT}' does not exist." >&2
+    exit 1
+fi
+
+rm -rf mac-deps || true
+mkdir -p mac-deps
+ln -sf "../${SRC_DIR}/${SRC_PYTHON}"  mac-deps/portable-python
+# Git is only bundled on x86_64; arm64 uses the system /usr/bin/git
+if [[ "$ARCH" != "arm64" ]]; then
+  ln -sf "../${SRC_DIR}/${SRC_GIT}"   mac-deps/portable-git
+else
+  # Create a placeholder for arm64 so extraFiles doesn't fail.
+  # electron-builder requires all extraFiles paths to exist at build time.
+  # The after-pack hook removes this directory since arm64 doesn't bundle git.
+  mkdir -p mac-deps/portable-git
+fi
+
+echo "   portable-python → ${SRC_DIR}/${SRC_PYTHON}"
+if [[ "$ARCH" != "arm64" ]]; then
+  echo "   portable-git    → ${SRC_DIR}/${SRC_GIT}"
+fi
+
+# ── 5. Build with electron-builder ────────────────────────────────────────
+# Uses `exec` to replace this shell process with electron-builder so that
+# Ctrl+C and other signals are forwarded directly (no orphaned processes).
+
+echo "▶ Running yarn install/build"
+if [ ! -d "node_modules" ]; then
+    echo "▶ node_modules missing, running yarn install..."
+    yarn install
+fi
+yarn build
+
+# ── 6. Clean stale release directories ────────────────────────────────────
+# electron-builder fails with ENOTEMPTY if stale build directories exist
+# from a previous interrupted build. Clean them up before running the build.
+
+case "$ARCH" in
+  x86_64) EB_ARCH="x64" ;;
+  arm64)  EB_ARCH="arm64" ;;
+esac
+
+for dir in release/mac-"${EB_ARCH}" release/mac-"${EB_ARCH}".tmp; do
+  if [ -e "$dir" ]; then
+    echo "▶ Removing stale $dir"
+    rm -rf "$dir"
+  fi
+done
+
+echo "▶ Running electron-builder --mac --${EB_ARCH}"
+exec npx electron-builder --mac --"${EB_ARCH}"

--- a/dependencies/BUILD-MAC.md
+++ b/dependencies/BUILD-MAC.md
@@ -1,0 +1,199 @@
+# macOS Build Flow (build-mac.sh)
+
+Quick reference for building the ExpressLRS Configurator native app on macOS.
+
+## Prerequisites
+
+- macOS (Intel or Apple Silicon)
+- Node.js and Yarn installed
+
+## Usage
+
+```bash
+./build-mac.sh arm64         # Apple Silicon (M1/M2/M3/etc.)
+./build-mac.sh x86_64        # Intel (x86)
+./build-mac.sh -a            # auto-detect native architecture and build
+./build-mac.sh -h            # show help message
+```
+
+> **Note:** Running the script with no arguments displays the help message. Use `-a` or `--auto` to build for the detected architecture.
+
+## Build Flow Overview
+
+```mermaid
+flowchart TD
+    subgraph buildmac["build-mac.sh"]
+        S1["Step 1: Detect arch"] --> S2["Step 2: Resolve dirs"]
+        S2 --> S3["Step 3: Validate & auto-download"]
+        S3 --> S4["Step 4: Create mac-deps/ symlinks"]
+        S4 --> S5["Step 5: electron-builder"]
+    end
+
+    S5 --> AP["after-pack.js hook"]
+    AP --> App["ExpressLRS Configurator.app"]
+
+    style buildmac fill:#f0f0f0,stroke:#666
+    style AP fill:#fff3cd,stroke:#856404
+    style App fill:#d4edda,stroke:#155724
+```
+
+## Detailed Steps
+
+### Step 1: Architecture Detection
+
+Determines the target architecture from a CLI argument or the `-a`/`--auto` flag. Without any arguments, the script displays a help message. With `-a`, it auto-detects via `uname -m`. Returns `"arm64"` on Apple Silicon and `"x86_64"` on Intel Macs. Common aliases are supported (`intel`, `aarch64`, `"apple-silicon"`).
+
+### Step 2: Toolchain Directory Resolution
+
+Maps the resolved architecture to its corresponding toolchain root and directory names. These variables feed into the symlink creation step below, allowing `package.json` to reference stable paths regardless of architecture.
+
+### Step 3: Dependency Validation (arm64 only)
+
+Checks whether `dependencies/darwin_arm64/portable-python-3.14.6` exists and is non-empty. If missing (e.g., fresh checkout, after cleanup), the build script automatically runs `dependencies/darwin_arm64/download-portable-python.sh` to download and prepare it. A defensive re-check verifies the directory exists after the download; if not, the build fails with a clear error message.
+
+### Step 4: mac-deps/ Symlink Creation
+
+Creates or refreshes the `mac-deps/` directory with symlinks pointing to the correct architecture-specific toolchain directories. These stable paths (`mac-deps/portable-python`, and `mac-deps/portable-git` on x64) are what `package.json` references in its `extraFiles` configuration.
+
+**Why portable-git is in extraFiles for both architectures:** The `extraFiles` config in `package.json` lists both `portable-python` and `portable-git` unconditionally. On arm64, `build-mac.sh` creates an empty `mac-deps/portable-git` placeholder directory so electron-builder doesn't fail. The `after-pack.js` hook then removes this placeholder from the final `.app` — only `portable-python` ends up bundled.
+
+### Step 5: electron-builder Invocation
+
+Runs `yarn install && yarn build` to compile the application, then delegates to `electron-builder --mac --${ARCH}` using `exec` so that Ctrl+C and other signals are forwarded directly (no orphaned processes).
+
+## Architecture-Specific Behavior
+
+| Feature | arm64 (Apple Silicon) | x86_64 (Intel) |
+|---------|----------------------|----------------|
+| Python | `portable-python-3.14.6` (bundled) | `python-portable-darwin-3.8.4` (bundled) |
+| Git | System `/usr/bin/git` — **not bundled** | `git-2.29.2` (bundled) |
+
+## The mac-deps/ Abstraction Layer
+
+The `mac-deps/` directory provides a stable, architecture-independent interface between the build script and electron-builder. Without it, `package.json` would need arch-specific configuration or multiple build targets.
+
+**How it works:**
+
+1. **`build-mac.sh` creates symlinks at build time:**
+   ```
+   mac-deps/portable-python → ../dependencies/darwin_arm64/portable-python-3.14.6  (arm64)
+   mac-deps/portable-python → ../dependencies/darwin_amd64/python-portable-darwin-3.8.4  (x64)
+   mac-deps/portable-git    → ../dependencies/darwin_amd64/git-2.29.2              (x64 only)
+   ```
+
+2. **`package.json` references stable paths:**
+   ```json
+   { "from": "mac-deps/portable-python", "to": "dependencies/portable-python" }
+   ```
+   Electron-builder copies these symlinks into the `.app` at the runtime path `dependencies/portable-python`.
+
+3. **`scripts/after-pack.js` renames to arch-specific names:**
+   ```
+   dependencies/portable-python  →  dependencies/portable-python-arm64  (or x64)
+   dependencies/portable-git     →  dependencies/portable-git-x64       (x64 only)
+   ```
+
+The runtime code (`src/main/main.ts`) then discovers these arch-specific directories to set up the `PATH` environment variable.
+
+## Directory Structure
+
+```
+dependencies/
+├── darwin_arm64/                          # Apple Silicon toolchains
+│   ├── download-portable-python.sh        # Auto-download script (see Step 3)
+│   └── portable-python-3.14.6/            # Bundled into .app as port...-python-arm64
+│       ├── bin/python                     # Standalone Python 3.14.6
+│       ├── bin/pip                        # pip with pyserial + setuptools installed
+│       └── (other Python runtime files)
+│
+├── darwin_amd64/                          # Intel toolchains
+│   ├── git-2.29.2/                        # Bundled into .app as portable-git-x64
+│   └── python-portable-darwin-3.8.4/      # Bundled into .app as port...-python-x64
+│       ├── bin/python
+│       └── (other Python runtime files)
+│
+├── windows_amd64/                         # Windows toolchains (not covered here)
+│   ├── PortableGit/
+│   └── python/
+ │
+└── get-platformio.py                      # PlatformIO installer (bundled into .app)
+
+mac-deps/                                  # Created fresh by build-mac.sh (gitignored)
+├── portable-python → ../dependencies/...  # Symlink (arch-specific at build time)
+└── portable-git → ../dependencies/...     # Symlink (x64 only)
+```
+
+**Inside the built `.app`:**
+
+```
+ExpressLRS Configurator.app/
+└── Contents/
+    ├── dependencies/                      # electron-builder extraFiles go here
+    │   ├── portable-python-arm64/         # Renamed by after-pack.js
+    │   └── portable-python-x64/           # Renamed by after-pack.js
+    │   ├── portable-git-x64/              # Only on x64 builds
+    │  └── get-platformio.py              # Bundled from package.json extraFiles
+```
+
+## Troubleshooting
+
+### Missing portable dependencies on arm64
+
+**Error:** `Error: dependencies/darwin_arm64/portable-python-3.14.6 is still missing after running download script.`
+
+**Fix:** The build script attempts to auto-download, but if it fails (network error, server unavailable), run the download script manually:
+```bash
+cd dependencies/darwin_arm64 && ./download-portable-python.sh
+```
+
+### Stale mac-deps/ directory
+
+**Symptom:** The build fails with `portable-git not found` or similar, even though you just ran the build.
+
+**Cause:** A previous architecture's `mac-deps/` directory may still exist as a real directory instead of symlinks.
+
+**Fix:** `build-mac.sh` handles this automatically by running `rm -rf mac-deps || true` before creating fresh symlinks. No manual intervention needed — just re-run the build script with your target architecture:
+```bash
+./build-mac.sh arm64
+```
+
+### Building the wrong architecture
+
+**Error:** `▶ Building for macOS x86_64` when you expected arm64 on Apple Silicon.
+
+**Cause:** `uname -m` returns the native architecture, but you may be running under Rosetta 2 translation.
+
+**Fix:** Explicitly specify the architecture:
+```bash
+# Force arm64 even if running under Rosetta
+./build-mac.sh arm64
+
+# Force x86_64 on Apple Silicon
+./build-mac.sh x86_64
+
+# Use auto-detection
+./build-mac.sh -a
+```
+
+### Build failures from electron-builder
+
+**Symptom:** Electron-builder exits with an error but no portable-toolchain-related messages.
+
+**Fixes to try:**
+1. Clear the build cache: `rm -rf release/`
+2. Ensure Node.js and Yarn are installed and functional: `node --version && yarn --version`
+3. Run a clean build from scratch: remove `mac-deps/`, then re-run `./build-mac.sh arm64` (or `x86_64`)
+4. Check the full electron-builder log output for dependency or signing errors
+
+### Manually rebuild portable-python (arm64)
+
+To force a re-download of the arm64 Python toolchain:
+```bash
+rm -rf dependencies/darwin_arm64/portable-python-3.14.6
+./build-mac.sh arm64
+```
+
+The build script will detect the missing directory and run `download-portable-python.sh` automatically. If you want to skip the build and only download:
+```bash
+cd dependencies/darwin_arm64 && ./download-portable-python.sh
+```

--- a/dependencies/BUILD-MAC.md
+++ b/dependencies/BUILD-MAC.md
@@ -26,10 +26,12 @@ flowchart TD
         S1["Step 1: Detect arch"] --> S2["Step 2: Resolve dirs"]
         S2 --> S3["Step 3: Validate & auto-download"]
         S3 --> S4["Step 4: Create mac-deps/ symlinks"]
-        S4 --> S5["Step 5: electron-builder"]
+        S4 --> S5["Step 5: yarn install/build"]
+        S5 --> S6["Step 6: Clean stale release dirs"]
+        S6 --> S7["Step 7: electron-builder"]
     end
 
-    S5 --> AP["after-pack.js hook"]
+    S7 --> AP["after-pack.js hook"]
     AP --> App["ExpressLRS Configurator.app"]
 
     style buildmac fill:#f0f0f0,stroke:#666
@@ -57,9 +59,17 @@ Creates or refreshes the `mac-deps/` directory with symlinks pointing to the cor
 
 **Why portable-git is in extraFiles for both architectures:** The `extraFiles` config in `package.json` lists both `portable-python` and `portable-git` unconditionally. On arm64, `build-mac.sh` creates an empty `mac-deps/portable-git` placeholder directory so electron-builder doesn't fail. The `after-pack.js` hook then removes this placeholder from the final `.app` — only `portable-python` ends up bundled.
 
-### Step 5: electron-builder Invocation
+### Step 5: yarn install/build
 
-Runs `yarn install && yarn build` to compile the application, then delegates to `electron-builder --mac --${ARCH}` using `exec` so that Ctrl+C and other signals are forwarded directly (no orphaned processes).
+Conditionally runs `yarn install --frozen-lockfile` only if `node_modules/` is missing, then runs `yarn build` to compile the application.
+
+### Step 6: Clean Stale Release Directories
+
+Removes any stale `release/mac-${arch}` and `release/mac-${arch}.tmp` directories from a previous interrupted build. Without this cleanup, electron-builder can fail with `ENOTEMPTY`.
+
+### Step 7: electron-builder Invocation
+
+Delegates to `electron-builder --mac --${ARCH}` using `exec` so that Ctrl+C and other signals are forwarded directly (no orphaned processes).
 
 ## Architecture-Specific Behavior
 

--- a/dependencies/build-mac.sh
+++ b/dependencies/build-mac.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Build macOS app for x86_64 (Intel) or arm64 (Apple Silicon).
+#
+# Usage:
+#   ./build-mac.sh arm64        → build Apple Silicon (ARM)
+#   ./build-mac.sh x86_64       → build Intel (x86)
+#   ./build-mac.sh -a           → auto-detect architecture and build
+#   ./build-mac.sh -h           → show help
+#
+# How it works:
+#   1. Resolves the correct portable toolchain directories for the target arch.
+#   2. Creates symlinks in mac-deps/ (portable-python always, portable-git on x64 only).
+#   3. Runs electron-builder which bundles mac-deps/ into the .app via extraFiles
+#      in package.json. The after-pack hook then renames them to arch-specific names
+#      (e.g., portable-python-arm64, portable-git-x64).
+#   4. On arm64, no portable-git is bundled — the app uses /usr/bin/git from macOS.
+#   5. On x64, portable-git is bundled and used at runtime from dependencies/.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# ── Help ───────────────────────────────────────────────────────────────────
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options] [arch]
+
+Build macOS app for x86_64 (Intel) or arm64 (Apple Silicon).
+
+Options:
+  -h, --help      Show this help message
+  -a, --auto      Auto-detect architecture
+
+Architectures:
+  arm64, aarch64  Build for Apple Silicon Macs
+  x86_64, intel   Build for Intel Macs
+
+Examples:
+  $(basename "$0") arm64        # build for Apple Silicon
+  $(basename "$0") -a           # auto-detect and build
+  $(basename "$0") x86_64        # build for Intel Macs
+EOF
+}
+
+# ── Parse flags ────────────────────────────────────────────────────────────
+AUTO=false
+ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help) usage; exit 0 ;;
+        -a|--auto) AUTO=true ;;
+        *) ARGS+=("$arg") ;;
+    esac
+done
+
+# Show help if no arguments provided
+if [[ ${#ARGS[@]} -eq 0 && "$AUTO" == "false" ]]; then
+    usage
+    exit 0
+fi
+
+# ── Portable toolchain configuration ───────────────────────────────────────
+# These directories must exist before building. They contain pre-built,
+# self-contained copies of Python and Git with all their shared libraries
+# bundled alongside them (using @loader_path relative paths).
+
+ARM64_DIR="dependencies/darwin_arm64"
+ARM64_PYTHON="portable-python-3.14.6"
+
+X64_DIR="dependencies/darwin_amd64"
+X64_PYTHON="python-portable-darwin-3.8.4"
+X64_GIT="git-2.29.2"
+
+# ── 1. Detect architecture ────────────────────────────────────────────────
+# Use -a/--auto to auto-detect from uname -m, or use the first CLI argument if provided.
+# Auto-detection returns "arm64" on Apple Silicon and "x86_64" on Intel Macs.
+# When -a/--auto is used, any architecture argument is ignored.
+if [[ "$AUTO" == "true" ]]; then ARCH="$(uname -m)"; ARCH_SOURCE="auto-detected"
+else ARCH="${ARGS[0]}"; ARCH_SOURCE="from CLI"; fi
+
+# Normalize common aliases so users can pass "intel", "aarch64", etc.
+case "$ARCH" in
+  x86_64|intel|x86)
+    ARCH="x86_64" ;;
+  arm64|aarch64|"apple-silicon")
+    ARCH="arm64" ;;
+  *)
+    echo "Error: unknown architecture '$ARCH'. Use x86_64 or arm64." >&2
+    echo "Run with -h for usage." >&2
+    exit 1 ;;
+esac
+
+echo "▶ Building for macOS ${ARCH} (${ARCH_SOURCE})"
+
+# ── 2. Resolve source directories ─────────────────────────────────────────
+# Map the resolved arch to the correct toolchain root, Python dir name,
+# and Git dir name. These feed into the symlink creation step below.
+
+case "$ARCH" in
+  x86_64)
+    SRC_DIR=$X64_DIR
+    SRC_PYTHON=$X64_PYTHON
+    SRC_GIT=$X64_GIT
+    ;;
+  arm64)
+    SRC_DIR=$ARM64_DIR
+    SRC_PYTHON=$ARM64_PYTHON
+    ;;
+esac
+
+# ── 3. Ensure arm64 portable dependencies exist ────────────────────────
+# Only arm64 requires this check. x86_64 portable tools (python, git) are
+# pre-bundled in the repo as stable upstream releases. arm64 portable python is
+# custom-built and may not exist on a fresh checkout or after cleanup.
+
+if [[ "$ARCH" == "arm64" ]]; then
+    python_dir="${SRC_DIR}/${ARM64_PYTHON}"
+    if [ ! -d "$python_dir" ] || [ -z "$(ls -A "$python_dir")" ]; then
+        echo "▶ Downloading missing portable dependencies for arm64..." >&2
+        bash "${ARM64_DIR}/download-portable-python.sh" 2>&1 || {
+            echo "Error: download-portable-python.sh failed." >&2
+            exit 1
+        }
+
+        # Verify the download succeeded
+        if [ ! -d "$python_dir" ] || [ -z "$(ls -A "$python_dir")" ]; then
+            echo "Error: $python_dir is still missing after running download script." >&2
+            exit 1
+        fi
+    fi
+fi
+
+# ── 4. Create mac-deps/ symlinks ─────────────────────────────────────────
+# Removes any existing mac-deps (real directory or stale symlinks) and creates
+# fresh symlinks pointing to the correct arch-specific toolchain directories.
+# These stable mac-deps/ paths are what package.json references in extraFiles,
+# so the build script and electron-builder never need arch-specific config.
+# For arm64, a placeholder portable-git directory is created instead of a
+# symlink (since arm64 doesn't bundle git). The after-pack hook removes it.
+
+echo "▶ creating mac-deps symlinks for ${ARCH}"
+# Validate source directories exist before creating symlinks
+if [ ! -d "$SRC_DIR" ]; then
+    echo "Error: source directory '$SRC_DIR' does not exist." >&2
+    exit 1
+fi
+if [ ! -d "${SRC_DIR}/${SRC_PYTHON}" ]; then
+    echo "Error: python directory '${SRC_DIR}/${SRC_PYTHON}' does not exist." >&2
+    exit 1
+fi
+if [[ "$ARCH" != "arm64" ]] && [ ! -d "${SRC_DIR}/${SRC_GIT}" ]; then
+    echo "Error: git directory '${SRC_DIR}/${SRC_GIT}' does not exist." >&2
+    exit 1
+fi
+
+rm -rf mac-deps || true
+mkdir -p mac-deps
+ln -sf "../${SRC_DIR}/${SRC_PYTHON}"  mac-deps/portable-python
+# Git is only bundled on x86_64; arm64 uses the system /usr/bin/git
+if [[ "$ARCH" != "arm64" ]]; then
+  ln -sf "../${SRC_DIR}/${SRC_GIT}"   mac-deps/portable-git
+else
+  # Create a placeholder for arm64 so extraFiles doesn't fail.
+  # electron-builder requires all extraFiles paths to exist at build time.
+  # The after-pack hook removes this directory since arm64 doesn't bundle git.
+  mkdir -p mac-deps/portable-git
+fi
+
+echo "   portable-python → ${SRC_DIR}/${SRC_PYTHON}"
+if [[ "$ARCH" != "arm64" ]]; then
+  echo "   portable-git    → ${SRC_DIR}/${SRC_GIT}"
+fi
+
+# ── 5. Build with electron-builder ────────────────────────────────────────
+# Uses `exec` to replace this shell process with electron-builder so that
+# Ctrl+C and other signals are forwarded directly (no orphaned processes).
+
+echo "▶ Running yarn install/build"
+if [ ! -d "node_modules" ]; then
+    echo "▶ node_modules missing, running yarn install..."
+    yarn install --frozen-lockfile
+fi
+yarn build
+
+# ── 6. Clean stale release directories ────────────────────────────────────
+# electron-builder fails with ENOTEMPTY if stale build directories exist
+# from a previous interrupted build. Clean them up before running the build.
+
+case "$ARCH" in
+  x86_64) EB_ARCH="x64" ;;
+  arm64)  EB_ARCH="arm64" ;;
+esac
+
+for dir in release/mac-"${EB_ARCH}" release/mac-"${EB_ARCH}".tmp; do
+  if [ -e "$dir" ]; then
+    echo "▶ Removing stale $dir"
+    rm -rf "$dir"
+  fi
+done
+
+echo "▶ Running electron-builder --mac --${EB_ARCH}"
+exec npx electron-builder --mac --"${EB_ARCH}"

--- a/dependencies/build-mac.sh
+++ b/dependencies/build-mac.sh
@@ -198,4 +198,4 @@ for dir in release/mac-"${EB_ARCH}" release/mac-"${EB_ARCH}".tmp; do
 done
 
 echo "▶ Running electron-builder --mac --${EB_ARCH}"
-exec npx electron-builder --mac --"${EB_ARCH}"
+exec yarn electron-builder --mac --"${EB_ARCH}"

--- a/dependencies/build-mac.sh
+++ b/dependencies/build-mac.sh
@@ -17,7 +17,7 @@
 #   5. On x64, portable-git is bundled and used at runtime from dependencies/.
 
 set -euo pipefail
-cd "$(dirname "$0")"
+cd "$(cd "$(dirname "$0")/.." && pwd)"
 
 # ── Help ───────────────────────────────────────────────────────────────────
 usage() {

--- a/dependencies/darwin_arm64/download-portable-python.sh
+++ b/dependencies/darwin_arm64/download-portable-python.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# download-portable-python.sh — Fetch and prepare a standalone Python distribution for macOS arm64.
+#
+# Usage:
+#   cd dependencies/darwin_arm64 && ./download-portable-python.sh
+#
+# Output: Creates ./portable-python-<VERSION>/ with Python + required pip packages.
+# This directory is symlinked by build-mac.sh into mac-deps/portable-python and
+# bundled into the .app via electron-builder extraFiles.
+
+set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
+cd "$(dirname "$0")"
+
+# ── Configuration ─────────────────────────────────────────────────────────
+# Python version and download URL. The URL follows the astral-sh python-build-standalone
+# convention: cpython-<VERSION>+<DATE>-<TRIPLE>-install_only.tar.gz
+# Triple: aarch64-apple-darwin = ARM64 macOS
+
+NAME="portable-python"
+VERSION="3.14.6"
+PYTHON_URL="https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.14.6+20260610-aarch64-apple-darwin-install_only.tar.gz"
+
+# ── Output directory ─────────────────────────────────────────────────────
+PORTABLE="$(pwd -P 2>/dev/null)/${NAME}-${VERSION}"
+
+# ── Safety check ────────────────────────────────────────────────────────
+# Refuse to overwrite an existing non-empty directory. If you need to rebuild,
+# delete the directory manually first.
+
+if [ -d "$PORTABLE" ]; then
+    if [ -n "$(ls -A "${PORTABLE}" 2>/dev/null)" ]; then
+        echo "Error: ${PORTABLE} already exists and is not empty." >&2
+        exit 1
+    fi
+fi
+
+# ── Download and extract ───────────────────────────────────────────────
+curl -Lo python.tar.gz ${PYTHON_URL}
+tar xzf python.tar.gz
+mv python ${NAME}-${VERSION}
+rm python.tar.gz
+
+# ── Post-install fixups ───────────────────────────────────────────────
+# Upgrade pip, then install pyserial (needed for serial port flashing) and
+# setuptools (needed by some build tools). These are bundled into the .app.
+
+cd ${PORTABLE}/bin
+./python -m pip install --upgrade pip
+./pip install pyserial
+./pip install setuptools

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ export default tseslint.config(
       'dist/**',
       'dll/**',
       '.erb/**',
+      'scripts/**',
       '__snapshots__/**',
       'src/ui/gql/generated/types.ts',
       'assets/assets.d.ts',

--- a/package.json
+++ b/package.json
@@ -329,6 +329,10 @@
     "winston": "^3.11.0",
     "ws": "^8.16.0"
   },
+  "devEngines": {
+    "runtime": "node@24.x",
+    "packageManager": "yarn@>=1.21.3"
+  },
   "browserslist": [],
   "renovate": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "afterPack": "./scripts/after-pack.js",
     "appId": "org.expresslrs.configurator",
     "buildDependenciesFromSource": true,
-    "npmRebuild": true,
+    "npmRebuild": false,
     "files": [
       "dist/",
       "release/app/dist/",
@@ -330,7 +330,8 @@
     "ws": "^8.16.0"
   },
   "devEngines": {
-    "runtime": {"name": "node", "version": ">=24"}
+    "runtime": {"name": "node", "version": ">=24"},
+    "packageManager": {"name": "yarn", "version": ">=1.21.3"}
   },
   "browserslist": [],
   "renovate": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
         "dmg"
       ],
       "type": "distribution",
+      "hardenedRuntime": true,
+      "entitlements": "assets/entitlements.mac.plist",
+      "entitlementsInherit": "assets/entitlements.mac.plist",
+      "gatekeeperAssess": false,
       "category": "public.app-category.developer-tools",
       "extraFiles": [
         {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
   "main": "./src/main/main.ts",
   "build": {
     "productName": "ExpressLRS Configurator",
+    "afterPack": "./scripts/after-pack.js",
     "appId": "org.expresslrs.configurator",
+    "buildDependenciesFromSource": true,
+    "npmRebuild": true,
     "files": [
       "dist/",
       "release/app/dist/",
@@ -38,21 +41,28 @@
       "package.json",
       "devices/"
     ],
-    "afterSign": ".erb/scripts/notarize.js",
     "mac": {
+      "identity": null,
       "target": [
         "dmg"
       ],
       "type": "distribution",
-      "hardenedRuntime": true,
-      "entitlements": "assets/entitlements.mac.plist",
-      "entitlementsInherit": "assets/entitlements.mac.plist",
-      "gatekeeperAssess": false,
       "category": "public.app-category.developer-tools",
       "extraFiles": [
-        "dependencies/darwin_amd64",
-        "dependencies/get-platformio.py"
-      ]
+        {
+          "from": "mac-deps/portable-python",
+          "to": "dependencies/portable-python"
+        },
+        {
+          "from": "mac-deps/portable-git",
+          "to": "dependencies/portable-git"
+        },
+        {
+          "from": "dependencies/get-platformio.py",
+          "to": "dependencies/get-platformio.py"
+        }
+      ],
+      "cscLink": null
     },
     "dmg": {
       "contents": [
@@ -191,15 +201,17 @@
   },
   "resolutions": {},
   "devDependencies": {
-    "@electron/notarize": "^3.1.0",
     "@electron/rebuild": "^4.0.0",
+    "@eslint/js": "^9.0.0",
     "@graphql-codegen/cli": "^6.0.0",
     "@graphql-codegen/introspection": "^5.0.0",
+    "@graphql-codegen/typed-document-node": "^5.0.0",
     "@graphql-codegen/typescript": "^5.0.0",
     "@graphql-codegen/typescript-operations": "^5.0.0",
-    "@graphql-codegen/typed-document-node": "^5.0.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.0",
+    "@stylistic/eslint-plugin": "^4.0.0",
     "@teamsupercell/typings-for-css-modules-loader": "^2.5.2",
+    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@types/autosuggest-highlight": "^3.2.3",
@@ -218,9 +230,6 @@
     "@types/webpack-bundle-analyzer": "^4.6.3",
     "@types/webpack-env": "^1.18.4",
     "@types/webpack-node-externals": "^3.0.4",
-    "@eslint/js": "^9.0.0",
-    "@stylistic/eslint-plugin": "^4.0.0",
-    "typescript-eslint": "^8.0.0",
     "chalk": "^4.1.0",
     "concurrently": "^9.0.0",
     "core-js": "^3.35.0",
@@ -228,14 +237,16 @@
     "css-loader": "^7.0.0",
     "css-minimizer-webpack-plugin": "^7.0.0",
     "detect-port": "^2.0.0",
+    "dmg-builder": "^26.15.2",
     "electron": "^41.0.0",
-    "electron-builder": "^26.8.0",
+    "electron-builder": "^26.15.2",
+    "electron-builder-squirrel-windows": "^26.15.2",
     "eslint": "^9.0.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^5.0.0",
-    "globals": "^16.0.0",
     "file-loader": "^6.0.0",
+    "globals": "^16.0.0",
     "html-webpack-plugin": "^5.6.0",
     "husky": "^9.0.0",
     "identity-obj-proxy": "^3.0.0",
@@ -251,8 +262,10 @@
     "ts-jest": "^29.1.1",
     "ts-loader": "^9.5.1",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
+    "tslib": "^2.8.1",
     "tsx": "^4.21.0",
     "typescript": "^5.6.2",
+    "typescript-eslint": "^8.0.0",
     "url-loader": "^4.1.0",
     "webpack": "^5.73.0",
     "webpack-bundle-analyzer": "^5.0.0",
@@ -268,6 +281,7 @@
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.8",
+    "@graphql-yoga/subscription": "^5.0.0",
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^7.0.0",
     "@octokit/rest": "^22.0.0",
@@ -283,7 +297,6 @@
     "get-port": "^5.1.1",
     "graphql": "^16.7.1",
     "graphql-scalars": "^1.23.0",
-    "@graphql-yoga/subscription": "^5.0.0",
     "graphql-tag": "^2.12.6",
     "graphql-ws": "^6.0.6",
     "i18next": "^26.0.0",
@@ -301,6 +314,7 @@
     "react-router": "^7.0.0",
     "reflect-metadata": "^0.2.1",
     "regenerator-runtime": "^0.14.1",
+    "rxjs": "^7.8.2",
     "sanitize-filename": "^1.6.3",
     "semver": "^7.3.8",
     "simple-git": "^3.28.0",
@@ -310,11 +324,6 @@
     "typedi": "^0.10.0",
     "winston": "^3.11.0",
     "ws": "^8.16.0"
-  },
-  "devEngines": {
-    "node": ">=24.x",
-    "npm": ">=6.x",
-    "yarn": ">=1.21.3"
   },
   "browserslist": [],
   "renovate": {

--- a/package.json
+++ b/package.json
@@ -244,7 +244,6 @@
     "dmg-builder": "^26.15.2",
     "electron": "^41.0.0",
     "electron-builder": "^26.15.2",
-    "electron-builder-squirrel-windows": "^26.15.2",
     "eslint": "^9.0.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react": "^7.37.0",

--- a/package.json
+++ b/package.json
@@ -330,8 +330,7 @@
     "ws": "^8.16.0"
   },
   "devEngines": {
-    "runtime": "node@24.x",
-    "packageManager": "yarn@>=1.21.3"
+    "runtime": {"name": "node", "version": ">=24"}
   },
   "browserslist": [],
   "renovate": {

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -1,0 +1,94 @@
+/**
+ * after-pack.js — post-packaging hook for electron-builder.
+ *
+ * Electron-builder invokes this script after packaging each .app bundle.
+ * At this point, electron-builder has already copied extraFiles (from package.json)
+ * into a stable "dependencies/" directory inside the .app. This hook renames those
+ * directories to arch-specific names so the runtime code can find them.
+ *
+ * Example: electron-builder places portable-python at dependencies/portable-python.
+ *           This hook renames it to   dependencies/portable-python-arm64 (or x64).
+ *
+ * Arch-specific behavior:
+ *   - arm64: portable-python only (portable-git not bundled; app uses /usr/bin/git)
+ *   - x64:  portable-python + portable-git (both bundled from mac-deps/)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// ── Electron-builder arch enum → string mapping ─────────────────────────────
+// electron-builder passes arch as a numeric value; this maps it to the string
+// names used throughout the build pipeline (matching builder-util Arch).
+
+const ARCH_MAP = { 0: 'ia32', 1: 'x64', 2: 'armv7l', 3: 'arm64', 4: 'universal' };
+
+module.exports = async function ({ appOutDir, arch }) {
+  // ── 1. Resolve target architecture name ────────────────────────────────
+  const targetArch = ARCH_MAP[arch];
+
+  if (!targetArch) {
+    throw new Error(`Unrecognised arch value from electron-builder: ${JSON.stringify(arch)}`);
+  }
+
+  // ── 2. Locate the .app bundle within the output directory ───────────────
+  // electron-builder may produce multiple bundles; we take the first .app found.
+
+  const appBundles = fs.readdirSync(appOutDir).filter(
+    (f) => f.endsWith('.app') && fs.statSync(path.join(appOutDir, f)).isDirectory(),
+  );
+
+  if (appBundles.length === 0) {
+    throw new Error(`No .app bundle found in ${appOutDir}`);
+  }
+
+  const appName = appBundles[0]; // e.g. "ExpressLRS Configurator.app"
+  const depsDir = path.join(appOutDir, appName, 'Contents', 'dependencies');
+
+  if (!fs.existsSync(depsDir)) {
+    throw new Error(`Dependencies dir not found at ${depsDir}`);
+  }
+
+  // ── 3. Determine which portable tools to rename (arch-specific) ─────────
+  // Portable-python is always bundled. Portable-git is only bundled on x64;
+  // arm64 uses the system /usr/bin/git instead.
+
+  const entries = ['portable-python'];
+
+  if (targetArch === 'x64') {
+    entries.push('portable-git');
+  } else {
+    // Remove placeholder portable-git for arm64 (not needed, app uses system git)
+    const placeholderGit = path.join(depsDir, 'portable-git');
+    if (fs.existsSync(placeholderGit)) {
+      fs.rmSync(placeholderGit, { recursive: true, force: true });
+      console.log(`[afterPack] removed placeholder portable-git (arm64 uses system git)`);
+    }
+  }
+
+  // ── 4. Rename generic tool dirs to arch-specific names ─────────────────
+  // electron-builder places tools at stable paths (e.g. dependencies/portable-python).
+  // We rename them so the runtime code can discover arch-specific directories.
+
+  for (const name of entries) {
+    const srcPath = path.join(depsDir, name);
+
+    if (!fs.existsSync(srcPath)) {
+      throw new Error(`${name} not found at ${srcPath}`);
+    }
+
+    const targetName = `${name}-${targetArch}`;
+    const targetPath = path.join(depsDir, targetName);
+
+    // Remove stale arch-specific directory from a prior build
+    if (fs.existsSync(targetPath)) {
+      fs.rmSync(targetPath, { recursive: true, force: true });
+    }
+
+    // Rename to arch-specific name
+    fs.renameSync(srcPath, targetPath);
+    console.log(`[afterPack] renamed ${name} → ${targetName}`);
+  }
+
+  console.log(`[afterPack] done for arch=${targetArch} — ${appOutDir}/${appName}`);
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -280,20 +280,27 @@ const createWindow = async () => {
     PATH = prependPATH(PATH, portablePythonLocation);
     PATH = prependPATH(PATH, portableGitLocation);
   }
-  if (isMacOS) {
+  if (isMacOS && process.arch === 'arm64') {
     const portablePythonLocation = path.join(
       dependenciesPath,
-      'darwin_amd64/python-portable-darwin-3.8.4/bin',
+      'portable-python-arm64/bin',
+    );
+    PATH = prependPATH(PATH, portablePythonLocation);
+  }
+  if (isMacOS && process.arch === 'x64') {
+    const portablePythonLocation = path.join(
+      dependenciesPath,
+      'portable-python-x64/bin',
     );
     const portableGitLocation = path.join(
       dependenciesPath,
-      'darwin_amd64/git-2.29.2/bin',
+      'portable-git-x64/bin',
     );
     PATH = prependPATH(PATH, portablePythonLocation);
     PATH = prependPATH(PATH, portableGitLocation);
     localApiServerEnv.GIT_EXEC_PATH = path.join(
       dependenciesPath,
-      'darwin_amd64/git-2.29.2/libexec/git-core',
+      'portable-git-x64/libexec/git-core',
     );
   }
   localApiServerEnv.PATH = PATH;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -78,6 +78,8 @@ function resolveHtmlPath(htmlFileName: string, qs?: string) {
 
 const isWindows = process.platform.startsWith('win');
 const isMacOS = process.platform.startsWith('darwin');
+const isArm64 = process.arch === 'arm64';
+const isX64 = process.arch === 'x64';
 logger.log(`platform: ${process.platform}`);
 logger.log(`os release: ${process.getSystemVersion()}`);
 
@@ -280,14 +282,14 @@ const createWindow = async () => {
     PATH = prependPATH(PATH, portablePythonLocation);
     PATH = prependPATH(PATH, portableGitLocation);
   }
-  if (isMacOS && process.arch === 'arm64') {
+  if (isMacOS && isArm64) {
     const portablePythonLocation = path.join(
       dependenciesPath,
       'portable-python-arm64/bin',
     );
     PATH = prependPATH(PATH, portablePythonLocation);
   }
-  if (isMacOS && process.arch === 'x64') {
+  if (isMacOS && isX64) {
     const portablePythonLocation = path.join(
       dependenciesPath,
       'portable-python-x64/bin',


### PR DESCRIPTION
# Summary

This PR introduces a complete macOS build system that supports both x64 (Intel) and arm64 (Apple Silicon) architectures for the ExpressLRS Configurator native app.

This change:

- **Downloads portable Python (arm64 only)** from the trusted [astral-sh python-build-standalone](https://github.com/astral-sh/python-build-standalone/releases/tag/20250106) project instead of building locally
- **Bundles portable-git only on x64** — arm64 uses the system `/usr/bin/git` (no need to bundle it)
- **Auto-detects architecture** via `-a`/`--auto` flag or direct CLI argument (`arm64`, `x86_64`)
- **Shows help by default** when run without arguments (`-h` also works)
- **Creates arch-stable symlinks** in `mac-deps/` so electron-builder always uses the same paths regardless of target
- **Renames bundled dependencies** at build time via an `after-pack` hook so the runtime code finds them correctly

# Changes

## New files
| File | Purpose |
|------|---------|
| `build-mac.sh` | Main build script — help by default, arch detection, dependency checks, symlink creation, electron-builder |
| `BUILD-MAC.md` | Documentation for local and CI usage |
| `scripts/after-pack.js` | Electron-builder hook that renames portable tools to arch-specific names (`portable-python-arm64`, `portable-git-x64`) |

## Modified files
| File | What changed |
|------|--------------|
| `.gitignore` | Added portable-python arm64 directories, AGENTS.md, and ~~yarn.lock~~ .opencode to ignore list |
| `dependencies/darwin_arm64/download-portable-python.sh` | Now downloads from astral-sh v3.14.6 standalone release; installs pyserial + setuptools |
| `package.json` | extraFiles now uses arch-stable `mac-deps/` paths; after-pack hook handles arch-specific renaming; removed invalid `devEngines` block (npm 11 only recognizes `runtime`/`packageManager`/`cpu` there, not `node`/`npm`/`yarn`) |
| `src/main/main.ts` | Removed portable-git PATH and GIT_EXEC_PATH setup for arm64 (uses system git now) |

## Removed files
| File | Reason |
|------|--------|
|~~`yarn.lock`~~ | ~~Removed from tracking — CI performs fresh `yarn install` each run~~ |

## Architecture behavior
| Arch | Python | Git | Notes |
|------|--------|-----|-------|
| **x86_64 (Intel)** | Bundled portable-python | Bundled portable-git | App uses bundled git at runtime |
| **arm64 (Apple Silicon)** | Bundled portable-python | System `/usr/bin/git` | No git bundled; smaller .app size |
