### PR TITLE
Add binding phrase history

### DIFF
--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -213,6 +213,7 @@
   },
   "UserDefinesList": {
     "BindingPhraseHistory": "Recently used binding phrases",
+    "BindingPhraseHistoryRemove": "Remove from history",
     "CustomBindingPhrase": "Custom binding phrase",
     "MyStartupMelody": "My startup melody",
     "Value": "Value"

--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -212,6 +212,7 @@
     "DisableUARTInvertedWarning": "Disabling UART_INVERTED is uncommon. Please make sure that your transmitter supports that."
   },
   "UserDefinesList": {
+    "BindingPhraseHistory": "Recently used binding phrases",
     "CustomBindingPhrase": "Custom binding phrase",
     "MyStartupMelody": "My startup melody",
     "Value": "Value"

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -13,7 +13,7 @@ import {
   TextField,
   Tooltip,
 } from '@mui/material';
-import { History } from '@mui/icons-material';
+import { Close, History } from '@mui/icons-material';
 import { SxProps, Theme } from '@mui/system';
 import { useTranslation } from 'react-i18next';
 import {
@@ -36,6 +36,16 @@ const styles: Record<string, SxProps<Theme>> = {
       backgroundColor: 'transparent !important',
     },
   },
+  historyPhrase: {
+    marginRight: 2,
+  },
+};
+
+const maskPhrase = (phrase: string): string => {
+  if (phrase.length <= 8) {
+    return `${phrase.slice(0, 1)}•••`;
+  }
+  return `${phrase.slice(0, 3)}•••${phrase.slice(-3)}`;
 };
 
 interface UserDefinesListProps {
@@ -53,6 +63,7 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
   const [historyAnchorEl, setHistoryAnchorEl] = useState<HTMLElement | null>(
     null,
   );
+  const [showHistoryPhrases, setShowHistoryPhrases] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -60,6 +71,30 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
       setBindingPhraseHistory(await storage.getBindingPhraseHistory());
     })();
   }, []);
+
+  const onHistoryOpen
+    = (fieldName: string) =>
+      async (event: React.MouseEvent<HTMLElement>) => {
+        const anchor = event.currentTarget;
+        const storage = new ApplicationStorage();
+        const showData = await storage.getShowSensitiveFieldData(fieldName);
+        setShowHistoryPhrases(showData ?? false);
+        setHistoryAnchorEl(anchor);
+      };
+
+  const onHistoryClose = () => {
+    setHistoryAnchorEl(null);
+  };
+
+  const onRemoveBindingPhraseFromHistory = async (phrase: string) => {
+    const storage = new ApplicationStorage();
+    await storage.removeBindingPhraseFromHistory(phrase);
+    const updated = await storage.getBindingPhraseHistory();
+    setBindingPhraseHistory(updated);
+    if (updated.length === 0) {
+      onHistoryClose();
+    }
+  };
 
   const onChecked = (data: UserDefineKey) => {
     const opt = options.find(({ key }) => key === data);
@@ -164,9 +199,7 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                     >
                       <IconButton
                         aria-label={t('UserDefinesList.BindingPhraseHistory')}
-                        onClick={(event) => {
-                          setHistoryAnchorEl(event.currentTarget);
-                        }}
+                        onClick={onHistoryOpen(item.key)}
                       >
                         <History />
                       </IconButton>
@@ -174,9 +207,7 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                     <Menu
                       anchorEl={historyAnchorEl}
                       open={historyAnchorEl !== null}
-                      onClose={() => {
-                        setHistoryAnchorEl(null);
-                      }}
+                      onClose={onHistoryClose}
                     >
                       {bindingPhraseHistory.map((phrase) => (
                         <MenuItem
@@ -186,10 +217,25 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                               ...item,
                               value: phrase,
                             });
-                            setHistoryAnchorEl(null);
+                            onHistoryClose();
                           }}
                         >
-                          {phrase}
+                          <ListItemText sx={styles.historyPhrase}>
+                            {showHistoryPhrases ? phrase : maskPhrase(phrase)}
+                          </ListItemText>
+                          <IconButton
+                            size="small"
+                            edge="end"
+                            aria-label={t(
+                              'UserDefinesList.BindingPhraseHistoryRemove',
+                            )}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onRemoveBindingPhraseFromHistory(phrase);
+                            }}
+                          >
+                            <Close fontSize="small" />
+                          </IconButton>
                         </MenuItem>
                       ))}
                     </Menu>

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -1,14 +1,19 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect, useState } from 'react';
 import {
   Checkbox,
+  IconButton,
   List,
   ListItem,
   ListItemButton,
   ListItemIcon,
   ListItemSecondaryAction,
   ListItemText,
+  Menu,
+  MenuItem,
   TextField,
+  Tooltip,
 } from '@mui/material';
+import { History } from '@mui/icons-material';
 import { SxProps, Theme } from '@mui/system';
 import { useTranslation } from 'react-i18next';
 import {
@@ -19,6 +24,7 @@ import {
 import Omnibox from '../Omnibox';
 import UserDefineDescription from '../UserDefineDescription';
 import SensitiveTextField from '../SensitiveTextField';
+import ApplicationStorage from '../../storage';
 
 const styles: Record<string, SxProps<Theme>> = {
   icon: {
@@ -40,6 +46,20 @@ interface UserDefinesListProps {
 const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
   const { options, onChange } = props;
   const { t } = useTranslation();
+
+  const [bindingPhraseHistory, setBindingPhraseHistory] = useState<string[]>(
+    [],
+  );
+  const [historyAnchorEl, setHistoryAnchorEl] = useState<HTMLElement | null>(
+    null,
+  );
+
+  useEffect(() => {
+    (async () => {
+      const storage = new ApplicationStorage();
+      setBindingPhraseHistory(await storage.getBindingPhraseHistory());
+    })();
+  }, []);
 
   const onChecked = (data: UserDefineKey) => {
     const opt = options.find(({ key }) => key === data);
@@ -135,6 +155,45 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                     fullWidth
                     label={inputLabel(item.key)}
                   />
+                )}
+                {item.key === UserDefineKey.BINDING_PHRASE
+                  && bindingPhraseHistory.length > 0 && (
+                  <>
+                    <Tooltip
+                      title={t('UserDefinesList.BindingPhraseHistory')}
+                    >
+                      <IconButton
+                        aria-label={t('UserDefinesList.BindingPhraseHistory')}
+                        onClick={(event) => {
+                          setHistoryAnchorEl(event.currentTarget);
+                        }}
+                      >
+                        <History />
+                      </IconButton>
+                    </Tooltip>
+                    <Menu
+                      anchorEl={historyAnchorEl}
+                      open={historyAnchorEl !== null}
+                      onClose={() => {
+                        setHistoryAnchorEl(null);
+                      }}
+                    >
+                      {bindingPhraseHistory.map((phrase) => (
+                        <MenuItem
+                          key={phrase}
+                          onClick={() => {
+                            onChange({
+                              ...item,
+                              value: phrase,
+                            });
+                            setHistoryAnchorEl(null);
+                          }}
+                        >
+                          {phrase}
+                        </MenuItem>
+                      ))}
+                    </Menu>
+                  </>
                 )}
               </ListItem>
             )}

--- a/src/ui/storage/index.ts
+++ b/src/ui/storage/index.ts
@@ -59,6 +59,10 @@ export interface IApplicationStorage {
   setThemeMode(value: string): void;
 
   getThemeMode(): string | null;
+
+  getBindingPhraseHistory(): Promise<string[]>;
+
+  addBindingPhraseToHistory(phrase: string): Promise<void>;
 }
 
 const DEVICE_OPTIONS_BY_TARGET_KEYSPACE = 'device_options';
@@ -66,6 +70,8 @@ const FIRMWARE_SOURCE_KEY = 'firmware_source';
 const UI_SHOW_FIRMWARE_PRE_RELEASES = 'ui_show_pre_releases';
 const EXPERT_MODE = 'expert_mode';
 const THEME_MODE_KEY = 'theme_mode';
+const BINDING_PHRASE_HISTORY_KEY = 'binding_phrase_history';
+const BINDING_PHRASE_HISTORY_LIMIT = 15;
 
 export default class ApplicationStorage implements IApplicationStorage {
   async saveDeviceOptions(
@@ -266,5 +272,37 @@ export default class ApplicationStorage implements IApplicationStorage {
 
   getThemeMode(): string | null {
     return localStorage.getItem(THEME_MODE_KEY);
+  }
+
+  async getBindingPhraseHistory(): Promise<string[]> {
+    const value = localStorage.getItem(BINDING_PHRASE_HISTORY_KEY);
+    if (value === null) {
+      return [];
+    }
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((item): item is string => {
+          return typeof item === 'string';
+        });
+      }
+      return [];
+    } catch (e) {
+      console.error(`failed to parse ${BINDING_PHRASE_HISTORY_KEY}`, e);
+      return [];
+    }
+  }
+
+  async addBindingPhraseToHistory(phrase: string): Promise<void> {
+    const trimmed = phrase.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    const history = await this.getBindingPhraseHistory();
+    const updated = [
+      trimmed,
+      ...history.filter((item) => item !== trimmed),
+    ].slice(0, BINDING_PHRASE_HISTORY_LIMIT);
+    localStorage.setItem(BINDING_PHRASE_HISTORY_KEY, JSON.stringify(updated));
   }
 }

--- a/src/ui/storage/index.ts
+++ b/src/ui/storage/index.ts
@@ -63,6 +63,8 @@ export interface IApplicationStorage {
   getBindingPhraseHistory(): Promise<string[]>;
 
   addBindingPhraseToHistory(phrase: string): Promise<void>;
+
+  removeBindingPhraseFromHistory(phrase: string): Promise<void>;
 }
 
 const DEVICE_OPTIONS_BY_TARGET_KEYSPACE = 'device_options';
@@ -303,6 +305,12 @@ export default class ApplicationStorage implements IApplicationStorage {
       trimmed,
       ...history.filter((item) => item !== trimmed),
     ].slice(0, BINDING_PHRASE_HISTORY_LIMIT);
+    localStorage.setItem(BINDING_PHRASE_HISTORY_KEY, JSON.stringify(updated));
+  }
+
+  async removeBindingPhraseFromHistory(phrase: string): Promise<void> {
+    const history = await this.getBindingPhraseHistory();
+    const updated = history.filter((item) => item !== phrase);
     localStorage.setItem(BINDING_PHRASE_HISTORY_KEY, JSON.stringify(updated));
   }
 }

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -629,6 +629,16 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
       deviceOptionsFormData.userDefineOptions,
     );
 
+    // remember the binding phrase that is actually used for a build
+    const bindingPhrase = userDefines.find(
+      (userDefine) =>
+        userDefine.key === UserDefineKey.BINDING_PHRASE && userDefine.enabled,
+    )?.value;
+    if (bindingPhrase) {
+      const storage = new ApplicationStorage();
+      storage.addBindingPhraseToHistory(bindingPhrase);
+    }
+
     if (device?.parent && device?.name) {
       const deviceName = getAbbreviatedDeviceName(device);
       // add the user define for the device name


### PR DESCRIPTION
Remembers the last 15 binding phrases that were actually used for a build (saved in ApplicationStorage when Build/Flash starts) and lets you pick one back via a small history menu next to the binding phrase field - handy when flashing many receivers or coming back to an older phrase you forgot.

Fixes #154