### PR TITLE
Add min/max validation for AUTO_WIFI_ON_INTERVAL

### DIFF
--- a/src/api/src/factories/TargetUserDefinesFactory.ts
+++ b/src/api/src/factories/TargetUserDefinesFactory.ts
@@ -88,7 +88,13 @@ export default class TargetUserDefinesFactory {
           true,
         );
       case UserDefineKey.AUTO_WIFI_ON_INTERVAL:
-        return UserDefine.Text(UserDefineKey.AUTO_WIFI_ON_INTERVAL, '60', true);
+        return UserDefine.Number(
+          UserDefineKey.AUTO_WIFI_ON_INTERVAL,
+          '60',
+          true,
+          1,
+          2147483,
+        );
       case UserDefineKey.RX_AS_TX:
         let rxAxTxTypes: string[] = [];
         if (this.platform?.startsWith('esp32')) {

--- a/src/api/src/models/UserDefine.ts
+++ b/src/api/src/models/UserDefine.ts
@@ -23,6 +23,12 @@ export default class UserDefine {
   @Field(() => String, { nullable: true })
   value?: string;
 
+  @Field(() => Number, { nullable: true })
+  min?: number;
+
+  @Field(() => Number, { nullable: true })
+  max?: number;
+
   @Field(() => UserDefineOptionGroup, { nullable: true })
   optionGroup?: UserDefineOptionGroup;
 
@@ -98,5 +104,18 @@ export default class UserDefine {
     enabled = false,
   ): UserDefine {
     return new UserDefine(UserDefineKind.Enum, key, enabled, value, enumValues);
+  }
+
+  static Number(
+    key: UserDefineKey,
+    value = '',
+    enabled = false,
+    min?: number,
+    max?: number,
+  ): UserDefine {
+    const userDefine = new UserDefine(UserDefineKind.Number, key, enabled, value);
+    userDefine.min = min;
+    userDefine.max = max;
+    return userDefine;
   }
 }

--- a/src/api/src/models/enum/UserDefineKind.ts
+++ b/src/api/src/models/enum/UserDefineKind.ts
@@ -4,6 +4,7 @@ enum UserDefineKind {
   Boolean = 'Boolean',
   Text = 'Text',
   Enum = 'Enum',
+  Number = 'Number',
 }
 
 registerEnumType(UserDefineKind, {

--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -214,7 +214,8 @@
   "UserDefinesList": {
     "CustomBindingPhrase": "Custom binding phrase",
     "MyStartupMelody": "My startup melody",
-    "Value": "Value"
+    "Value": "Value",
+    "ValueOutOfRange": "Enter a whole number between {{min}} and {{max}}"
   },
   "WifiDeviceList": {
     "Name": "Name",

--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -215,7 +215,8 @@
     "CustomBindingPhrase": "Custom binding phrase",
     "MyStartupMelody": "My startup melody",
     "Value": "Value",
-    "ValueOutOfRange": "Enter a whole number between {{min}} and {{max}}"
+    "ValueOutOfRange": "Enter a whole number between {{min}} and {{max}}",
+    "AllowedRange": "Allowed range: {{min}}–{{max}}"
   },
   "WifiDeviceList": {
     "Name": "Name",

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -37,6 +37,29 @@ interface UserDefinesListProps {
   onChange: (data: UserDefine) => void;
 }
 
+/*
+  Numeric user defines with an allowed range. AUTO_WIFI_ON_INTERVAL is in
+  seconds; the firmware keeps it in int32 milliseconds, hence the upper bound.
+*/
+const numericRanges: Partial<
+  Record<UserDefineKey, { min: number; max: number }>
+> = {
+  [UserDefineKey.AUTO_WIFI_ON_INTERVAL]: { min: 1, max: 2147483 },
+};
+
+const hasNumericRangeError = (item: UserDefine): boolean => {
+  const range = numericRanges[item.key];
+  if (range === undefined || !item.enabled) {
+    return false;
+  }
+  const value = (item.value ?? '').trim();
+  if (!/^-?\d+$/.test(value)) {
+    return true;
+  }
+  const parsed = Number(value);
+  return parsed < range.min || parsed > range.max;
+};
+
 const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
   const { options, onChange } = props;
   const { t } = useTranslation();
@@ -124,6 +147,27 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                     value={item.value}
                     fullWidth
                     label={inputLabel(item.key)}
+                    type={
+                      numericRanges[item.key] !== undefined ? 'number' : 'text'
+                    }
+                    inputProps={
+                      numericRanges[item.key] !== undefined
+                        ? {
+                            min: numericRanges[item.key]?.min,
+                            max: numericRanges[item.key]?.max,
+                            step: 1,
+                          }
+                        : undefined
+                    }
+                    error={hasNumericRangeError(item)}
+                    helperText={
+                      hasNumericRangeError(item)
+                        ? t('UserDefinesList.ValueOutOfRange', {
+                            min: numericRanges[item.key]?.min,
+                            max: numericRanges[item.key]?.max,
+                          })
+                        : undefined
+                    }
                   />
                 )}
                 {item.sensitive && (

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -42,6 +42,9 @@ interface UserDefinesListProps {
   Numeric user defines carry their allowed range on the model (min/max), defined
   in TargetUserDefinesFactory. AUTO_WIFI_ON_INTERVAL is in seconds; the firmware
   keeps it in int32 milliseconds, hence the upper bound.
+
+  This drives only the field's visual error/helper text; the build-blocking
+  enforcement lives in UserDefinesValidator.validateNumericRanges.
 */
 const hasNumericRangeError = (item: UserDefine): boolean => {
   if (item.type !== UserDefineKind.Number || !item.enabled) {

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import { SxProps, Theme } from '@mui/system';
 import { useTranslation } from 'react-i18next';
+import { TFunction } from 'i18next';
 import {
   UserDefine,
   UserDefineKey,
@@ -58,6 +59,23 @@ const hasNumericRangeError = (item: UserDefine): boolean => {
     return true;
   }
   return false;
+};
+
+/*
+  Helper text for numeric inputs: always show the allowed range so the user knows
+  the bounds up front; switch to the out-of-range message when the value is invalid.
+*/
+const numericHelperText = (
+  item: UserDefine,
+  t: TFunction,
+): string | undefined => {
+  if (item.type !== UserDefineKind.Number) {
+    return undefined;
+  }
+  const key = hasNumericRangeError(item)
+    ? 'UserDefinesList.ValueOutOfRange'
+    : 'UserDefinesList.AllowedRange';
+  return t(key, { min: item.min, max: item.max });
 };
 
 const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
@@ -162,14 +180,7 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                         : undefined
                     }
                     error={hasNumericRangeError(item)}
-                    helperText={
-                      hasNumericRangeError(item)
-                        ? t('UserDefinesList.ValueOutOfRange', {
-                            min: item.min,
-                            max: item.max,
-                          })
-                        : undefined
-                    }
+                    helperText={numericHelperText(item, t)}
                   />
                 )}
                 {item.sensitive && (

--- a/src/ui/components/UserDefinesList/index.tsx
+++ b/src/ui/components/UserDefinesList/index.tsx
@@ -38,18 +38,12 @@ interface UserDefinesListProps {
 }
 
 /*
-  Numeric user defines with an allowed range. AUTO_WIFI_ON_INTERVAL is in
-  seconds; the firmware keeps it in int32 milliseconds, hence the upper bound.
+  Numeric user defines carry their allowed range on the model (min/max), defined
+  in TargetUserDefinesFactory. AUTO_WIFI_ON_INTERVAL is in seconds; the firmware
+  keeps it in int32 milliseconds, hence the upper bound.
 */
-const numericRanges: Partial<
-  Record<UserDefineKey, { min: number; max: number }>
-> = {
-  [UserDefineKey.AUTO_WIFI_ON_INTERVAL]: { min: 1, max: 2147483 },
-};
-
 const hasNumericRangeError = (item: UserDefine): boolean => {
-  const range = numericRanges[item.key];
-  if (range === undefined || !item.enabled) {
+  if (item.type !== UserDefineKind.Number || !item.enabled) {
     return false;
   }
   const value = (item.value ?? '').trim();
@@ -57,7 +51,13 @@ const hasNumericRangeError = (item: UserDefine): boolean => {
     return true;
   }
   const parsed = Number(value);
-  return parsed < range.min || parsed > range.max;
+  if (item.min != null && parsed < item.min) {
+    return true;
+  }
+  if (item.max != null && parsed > item.max) {
+    return true;
+  }
+  return false;
 };
 
 const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
@@ -138,7 +138,9 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                 <UserDefineDescription userDefine={item.key} />
               </ListItemSecondaryAction>
             </ListItemButton>
-            {item.type === UserDefineKind.Text && item.enabled && (
+            {(item.type === UserDefineKind.Text
+              || item.type === UserDefineKind.Number)
+            && item.enabled && (
               <ListItem sx={styles.complimentaryItem}>
                 {!item.sensitive && (
                   <TextField
@@ -148,13 +150,13 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                     fullWidth
                     label={inputLabel(item.key)}
                     type={
-                      numericRanges[item.key] !== undefined ? 'number' : 'text'
+                      item.type === UserDefineKind.Number ? 'number' : 'text'
                     }
                     inputProps={
-                      numericRanges[item.key] !== undefined
+                      item.type === UserDefineKind.Number
                         ? {
-                            min: numericRanges[item.key]?.min,
-                            max: numericRanges[item.key]?.max,
+                            min: item.min ?? undefined,
+                            max: item.max ?? undefined,
                             step: 1,
                           }
                         : undefined
@@ -163,8 +165,8 @@ const UserDefinesList: FunctionComponent<UserDefinesListProps> = (props) => {
                     helperText={
                       hasNumericRangeError(item)
                         ? t('UserDefinesList.ValueOutOfRange', {
-                            min: numericRanges[item.key]?.min,
-                            max: numericRanges[item.key]?.max,
+                            min: item.min,
+                            max: item.max,
                           })
                         : undefined
                     }

--- a/src/ui/gql/generated/types.ts
+++ b/src/ui/gql/generated/types.ts
@@ -401,6 +401,8 @@ export type UserDefine = {
   readonly enabled: Scalars['Boolean']['output'];
   readonly enumValues?: Maybe<ReadonlyArray<Scalars['String']['output']>>;
   readonly key: UserDefineKey;
+  readonly max?: Maybe<Scalars['Float']['output']>;
+  readonly min?: Maybe<Scalars['Float']['output']>;
   readonly optionGroup?: Maybe<UserDefineOptionGroup>;
   readonly sensitive?: Maybe<Scalars['Boolean']['output']>;
   readonly type: UserDefineKind;
@@ -444,6 +446,7 @@ export enum UserDefineKey {
 }
 
 export enum UserDefineKind {
+  Number = 'Number',
   Boolean = 'Boolean',
   Enum = 'Enum',
   Text = 'Text'
@@ -475,7 +478,7 @@ export type AvailableFirmwareTargetsQuery = { readonly __typename?: 'Query', rea
 export type AvailableMulticastDnsDevicesListQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type AvailableMulticastDnsDevicesListQuery = { readonly __typename?: 'Query', readonly availableMulticastDnsDevicesList: ReadonlyArray<{ readonly __typename?: 'MulticastDnsInformation', readonly name: string, readonly version: string, readonly target: string, readonly type: string, readonly vendor: string, readonly ip: string, readonly dns: string, readonly port: number, readonly deviceName: string, readonly product: string, readonly options: ReadonlyArray<{ readonly __typename?: 'UserDefine', readonly type: UserDefineKind, readonly key: UserDefineKey, readonly enabled: boolean, readonly enumValues?: ReadonlyArray<string> | null, readonly value?: string | null, readonly sensitive?: boolean | null }> }> };
+export type AvailableMulticastDnsDevicesListQuery = { readonly __typename?: 'Query', readonly availableMulticastDnsDevicesList: ReadonlyArray<{ readonly __typename?: 'MulticastDnsInformation', readonly name: string, readonly version: string, readonly target: string, readonly type: string, readonly vendor: string, readonly ip: string, readonly dns: string, readonly port: number, readonly deviceName: string, readonly product: string, readonly options: ReadonlyArray<{ readonly __typename?: 'UserDefine', readonly type: UserDefineKind, readonly key: UserDefineKey, readonly enabled: boolean, readonly enumValues?: ReadonlyArray<string> | null, readonly value?: string | null, readonly min?: number | null, readonly max?: number | null, readonly sensitive?: boolean | null }> }> };
 
 export type BuildFlashFirmwareMutationVariables = Exact<{
   input: BuildFlashFirmwareInput;
@@ -531,7 +534,7 @@ export type TargetDeviceOptionsQueryVariables = Exact<{
 }>;
 
 
-export type TargetDeviceOptionsQuery = { readonly __typename?: 'Query', readonly targetDeviceOptions: ReadonlyArray<{ readonly __typename?: 'UserDefine', readonly type: UserDefineKind, readonly key: UserDefineKey, readonly enabled: boolean, readonly enumValues?: ReadonlyArray<string> | null, readonly value?: string | null, readonly optionGroup?: UserDefineOptionGroup | null, readonly sensitive?: boolean | null }> };
+export type TargetDeviceOptionsQuery = { readonly __typename?: 'Query', readonly targetDeviceOptions: ReadonlyArray<{ readonly __typename?: 'UserDefine', readonly type: UserDefineKind, readonly key: UserDefineKey, readonly enabled: boolean, readonly enumValues?: ReadonlyArray<string> | null, readonly value?: string | null, readonly min?: number | null, readonly max?: number | null, readonly optionGroup?: UserDefineOptionGroup | null, readonly sensitive?: boolean | null }> };
 
 export type DisconnectFromSerialDeviceMutationVariables = Exact<{ [key: string]: never; }>;
 
@@ -585,7 +588,7 @@ export type LuaScriptQuery = { readonly __typename?: 'Query', readonly luaScript
 export type MulticastDnsMonitorUpdatesSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MulticastDnsMonitorUpdatesSubscription = { readonly __typename?: 'Subscription', readonly multicastDnsMonitorUpdates: { readonly __typename?: 'MulticastDnsMonitorUpdate', readonly type: MulticastDnsEventType, readonly data: { readonly __typename?: 'MulticastDnsInformation', readonly name: string, readonly version: string, readonly target: string, readonly type: string, readonly vendor: string, readonly ip: string, readonly dns: string, readonly port: number, readonly deviceName: string, readonly product: string, readonly options: ReadonlyArray<{ readonly __typename?: 'UserDefine', readonly type: UserDefineKind, readonly key: UserDefineKey, readonly enabled: boolean, readonly enumValues?: ReadonlyArray<string> | null, readonly value?: string | null, readonly sensitive?: boolean | null }> } } };
+export type MulticastDnsMonitorUpdatesSubscription = { readonly __typename?: 'Subscription', readonly multicastDnsMonitorUpdates: { readonly __typename?: 'MulticastDnsMonitorUpdate', readonly type: MulticastDnsEventType, readonly data: { readonly __typename?: 'MulticastDnsInformation', readonly name: string, readonly version: string, readonly target: string, readonly type: string, readonly vendor: string, readonly ip: string, readonly dns: string, readonly port: number, readonly deviceName: string, readonly product: string, readonly options: ReadonlyArray<{ readonly __typename?: 'UserDefine', readonly type: UserDefineKind, readonly key: UserDefineKey, readonly enabled: boolean, readonly enumValues?: ReadonlyArray<string> | null, readonly value?: string | null, readonly min?: number | null, readonly max?: number | null, readonly sensitive?: boolean | null }> } } };
 
 export type GetTagsQueryVariables = Exact<{
   owner: Scalars['String']['input'];

--- a/src/ui/gql/queries/availableMulticastDnsDevicesList.graphql
+++ b/src/ui/gql/queries/availableMulticastDnsDevicesList.graphql
@@ -7,6 +7,8 @@ query availableMulticastDnsDevicesList{
         enabled
         enumValues
         value
+        min
+        max
         sensitive
       }
       version

--- a/src/ui/gql/queries/deviceOptions.graphql
+++ b/src/ui/gql/queries/deviceOptions.graphql
@@ -23,6 +23,8 @@ query targetDeviceOptions(
     enabled
     enumValues
     value
+    min
+    max
     optionGroup
     sensitive
   }

--- a/src/ui/gql/queries/multicastDnsMonitorUpdates.graphql
+++ b/src/ui/gql/queries/multicastDnsMonitorUpdates.graphql
@@ -9,6 +9,8 @@ subscription multicastDnsMonitorUpdates {
         enabled
         enumValues
         value
+        min
+        max
         sensitive
       }
       version

--- a/src/ui/views/ConfiguratorView/UserDefinesValidator.test.ts
+++ b/src/ui/views/ConfiguratorView/UserDefinesValidator.test.ts
@@ -50,3 +50,14 @@ describe('UserDefinesValidator numeric ranges', () => {
     expect(validator.validateNumericRanges([numeric('42')])).toHaveLength(0);
   });
 });
+
+describe('UserDefinesValidator.validate() gate (blocks build)', () => {
+  it('surfaces -11111 through the full validate() gate', () => {
+    const errs = new UserDefinesValidator().validate([numeric('-11111', 1, 2147483)]);
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs.some((e) => e.message.includes('greater than or equal to 1'))).toBe(true);
+  });
+  it('lets a valid value pass the full gate', () => {
+    expect(new UserDefinesValidator().validate([numeric('60', 1, 2147483)])).toHaveLength(0);
+  });
+});

--- a/src/ui/views/ConfiguratorView/UserDefinesValidator.test.ts
+++ b/src/ui/views/ConfiguratorView/UserDefinesValidator.test.ts
@@ -1,0 +1,52 @@
+import UserDefinesValidator from './UserDefinesValidator';
+import {
+  UserDefine,
+  UserDefineKey,
+  UserDefineKind,
+} from '../../gql/generated/types';
+
+const numeric = (value: string, min?: number, max?: number): UserDefine => ({
+  type: UserDefineKind.Number,
+  key: UserDefineKey.AUTO_WIFI_ON_INTERVAL,
+  enabled: true,
+  enumValues: null,
+  value,
+  min,
+  max,
+  optionGroup: null,
+  sensitive: false,
+});
+
+describe('UserDefinesValidator numeric ranges', () => {
+  const validator = new UserDefinesValidator();
+
+  it('accepts a value within range', () => {
+    expect(validator.validateNumericRanges([numeric('60', 1, 2147483)])).toHaveLength(0);
+  });
+
+  it('rejects a value below min (regression: -11111 was accepted)', () => {
+    const errs = validator.validateNumericRanges([numeric('-11111', 1, 2147483)]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toContain('greater than or equal to 1');
+  });
+
+  it('rejects a value above max', () => {
+    const errs = validator.validateNumericRanges([numeric('99999999', 1, 2147483)]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toContain('less than or equal to 2147483');
+  });
+
+  it('rejects a non-integer value', () => {
+    expect(validator.validateNumericRanges([numeric('1.5', 1, 2147483)])).toHaveLength(1);
+    expect(validator.validateNumericRanges([numeric('abc', 1, 2147483)])).toHaveLength(1);
+  });
+
+  it('ignores disabled numeric options', () => {
+    const option = { ...numeric('-11111', 1, 2147483), enabled: false };
+    expect(validator.validateNumericRanges([option])).toHaveLength(0);
+  });
+
+  it('handles a numeric option without bounds', () => {
+    expect(validator.validateNumericRanges([numeric('42')])).toHaveLength(0);
+  });
+});

--- a/src/ui/views/ConfiguratorView/UserDefinesValidator.ts
+++ b/src/ui/views/ConfiguratorView/UserDefinesValidator.ts
@@ -1,4 +1,8 @@
-import { UserDefine, UserDefineKey } from '../../gql/generated/types';
+import {
+  UserDefine,
+  UserDefineKey,
+  UserDefineKind,
+} from '../../gql/generated/types';
 
 export default class UserDefinesValidator {
   validateRegulatoryDomains(data: UserDefine[]): Error[] {
@@ -96,11 +100,52 @@ export default class UserDefinesValidator {
     return results;
   }
 
+  /*
+    Numeric user defines (UserDefineKind.Number) carry their allowed range on the
+    model as optional min/max (set in TargetUserDefinesFactory). Enforce it here so
+    an out-of-range value actually blocks the build — the input's visual error alone
+    does not prevent submission (e.g. a manually typed -11111).
+  */
+  validateNumericRanges(data: UserDefine[]): Error[] {
+    const results: Error[] = [];
+
+    data
+      .filter(
+        (option) =>
+          option.type === UserDefineKind.Number
+          && option.enabled
+          && option.value !== undefined
+          && option.value !== null,
+      )
+      .forEach((option) => {
+        const raw = (option.value ?? '').trim();
+        const label = option.key;
+        if (!/^-?\d+$/.test(raw)) {
+          results.push(new Error(`${label} must be a whole number`));
+          return;
+        }
+        const parsed = Number(raw);
+        if (option.min !== undefined && option.min !== null && parsed < option.min) {
+          results.push(
+            new Error(`${label} must be greater than or equal to ${option.min}`),
+          );
+        }
+        if (option.max !== undefined && option.max !== null && parsed > option.max) {
+          results.push(
+            new Error(`${label} must be less than or equal to ${option.max}`),
+          );
+        }
+      });
+
+    return results;
+  }
+
   validate(data: UserDefine[]): Error[] {
     return [
       ...this.validateRegulatoryDomains(data),
       ...this.validateBindingPhrase(data),
       ...this.validateStartupMelody(data),
+      ...this.validateNumericRanges(data),
     ];
   }
 }


### PR DESCRIPTION
Fixes #524

The auto-WiFi interval field accepted any text. It now renders as a numeric input constrained to **1–2147483 seconds** — the upper bound comes from the firmware storing the interval in int32 milliseconds — and shows an inline error when the value is not a whole number in range.

The allowed ranges live in a small `numericRanges` map in `UserDefinesList`, so validating further numeric user-defines later is a one-line addition. Happy to adjust the bounds if the team prefers a tighter practical maximum.