### PR TITLE
Prefer vendored esptool over a system-installed esptool when flashing

### DIFF
--- a/src/api/src/library/Platformio/index.ts
+++ b/src/api/src/library/Platformio/index.ts
@@ -7,6 +7,7 @@ import Commander, { CommandResult, NoOpFunc, OnOutputFunc } from '../Commander';
 import { LoggerService } from '../../logger';
 import UploadType from './Enum/UploadType';
 import Python from '../Python';
+import envFilter from '../envFilter';
 
 interface PlatformioCoreState {
   core_version: string;
@@ -30,19 +31,6 @@ const prependPATH = (pth: string, item: string): string => {
     return `${item}${path.delimiter}${pth}`;
   }
   return item;
-};
-
-const envFilter = (
-  env: NodeJS.ProcessEnv,
-  blacklist: string[],
-): NodeJS.ProcessEnv => {
-  const result: NodeJS.ProcessEnv = {};
-  Object.keys(env).forEach((key) => {
-    if (!blacklist.includes(key)) {
-      result[key] = env[key];
-    }
-  });
-  return result;
 };
 
 export default class Platformio {

--- a/src/api/src/library/Python/index.ts
+++ b/src/api/src/library/Python/index.ts
@@ -3,13 +3,20 @@ import path from 'path';
 import child_process from 'child_process';
 import Commander, { CommandResult, NoOpFunc, OnOutputFunc } from '../Commander';
 import { LoggerService } from '../../logger';
+import envFilter from '../envFilter';
 
 export default class Python {
+  private env: NodeJS.ProcessEnv;
+
   constructor(
     public PATH: string,
-    private env: NodeJS.ProcessEnv,
+    env: NodeJS.ProcessEnv,
     private logger: LoggerService,
-  ) {}
+  ) {
+    // Fix for https://github.com/ExpressLRS/ExpressLRS-Configurator/issues/440
+    const blacklistedEnvKeys = ['PYTHONPATH', 'PYTHONHOME'];
+    this.env = envFilter(env, blacklistedEnvKeys);
+  }
 
   async runPythonScript(
     script: string,
@@ -21,15 +28,10 @@ export default class Python {
     if (pyExec === null) {
       throw new Error('python executable not found');
     }
-    let spawnOptions = {
-      env: this.env,
+    const spawnOptions = {
+      ...options,
+      env: { ...this.env, ...(options.env ?? {}) },
     };
-    if (options !== undefined) {
-      spawnOptions = {
-        env: this.env,
-        ...options,
-      };
-    }
     return new Commander().runCommand(
       pyExec,
       [script, ...args],

--- a/src/api/src/library/envFilter.ts
+++ b/src/api/src/library/envFilter.ts
@@ -1,0 +1,14 @@
+const envFilter = (
+  env: NodeJS.ProcessEnv,
+  blacklist: string[],
+): NodeJS.ProcessEnv => {
+  const result: NodeJS.ProcessEnv = {};
+  Object.keys(env).forEach((key) => {
+    if (!blacklist.includes(key)) {
+      result[key] = env[key];
+    }
+  });
+  return result;
+};
+
+export default envFilter;

--- a/src/api/src/services/BinaryFlashingStrategy/BinaryConfigurator/index.ts
+++ b/src/api/src/services/BinaryFlashingStrategy/BinaryConfigurator/index.ts
@@ -249,6 +249,7 @@ export default class BinaryConfigurator {
     flasherPath: string,
     flags: string[][],
     onUpdate: OnOutputFunc = NoOpFunc,
+    env: NodeJS.ProcessEnv = {},
   ) {
     this.logger.log('flags', {
       flags: maskSensitiveFlags(flags),
@@ -259,6 +260,7 @@ export default class BinaryConfigurator {
       flasherPath,
       binaryConfiguratorArgs,
       onUpdate,
+      { env },
     );
   }
 }

--- a/src/api/src/services/BinaryFlashingStrategy/index.ts
+++ b/src/api/src/services/BinaryFlashingStrategy/index.ts
@@ -594,6 +594,18 @@ export default class BinaryFlashingStrategyService implements FlashingStrategy {
       await this.updateLogs(
         `> ${this.binaryConfigurator.formatCommand(flasherPath, flasherArgs)}`,
       );
+      // Make the firmware's vendored esptool win over an incompatible
+      // system-installed esptool in site-packages, see
+      // https://github.com/ExpressLRS/ExpressLRS-Configurator/issues/780
+      const vendoredEsptoolDir = path.join(
+        firmwareSourcePath,
+        'python',
+        'external',
+        'esptool',
+      );
+      const flasherEnv: NodeJS.ProcessEnv = fs.existsSync(vendoredEsptoolDir)
+        ? { PYTHONPATH: vendoredEsptoolDir }
+        : {};
       const binaryConfiguratorResult = await this.binaryConfigurator.run(
         flasherPath,
         flasherArgs,
@@ -601,6 +613,7 @@ export default class BinaryFlashingStrategyService implements FlashingStrategy {
           this.updateLogs(output);
           flashOutputParser(output);
         },
+        flasherEnv,
       );
       const finalStep = params.type === BuildJobType.Flash
         ? BuildFirmwareStep.FLASHING_FIRMWARE


### PR DESCRIPTION
On Linux the binary flasher (flasher.pyz / binary_configurator.py) runs under the system Python, so an incompatible esptool in site-packages (e.g. Fedora 44's esptool 5.x, which removed esptool.cmds.make_image) shadowed the esptool vendored by the firmware. Point PYTHONPATH at the firmware checkout's python/external/esptool for the flasher spawn so the matching vendored copy always wins.

Also apply the PYTHONPATH/PYTHONHOME env blacklist (#440) in the Python class, which previously received the unfiltered environment.

Fixes https://github.com/ExpressLRS/ExpressLRS/issues/3705