### PR TITLE
Fix for publish.yml in forked repos

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,11 @@ name: Publish
 
 on: workflow_dispatch
 
+# creating releases and uploading their assets needs a writable token, the
+# default workflow token is read only on newer repositories
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ${{ matrix.os }}
@@ -49,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           yarn build
-          yarn electron-builder --publish always --x64 --win
+          yarn electron-builder --publish always --x64 --win "-c.publish.owner=${{ github.repository_owner }}" "-c.publish.repo=${{ github.event.repository.name }}"
 
       - name: Download macOS portable dependencies
         if: matrix.os == 'macos-15'
@@ -77,7 +82,7 @@ jobs:
             unset CSC_LINK CSC_KEY_PASSWORD
           fi
           yarn build
-          yarn electron-builder --publish always --x64 --arm64 --mac
+          yarn electron-builder --publish always --x64 --arm64 --mac "-c.publish.owner=${{ github.repository_owner }}" "-c.publish.repo=${{ github.event.repository.name }}"
 
       - name: Publish Linux releases
         if: matrix.os == 'ubuntu-22.04'
@@ -91,4 +96,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           yarn build
-          yarn electron-builder --publish always --x64 --linux
+          yarn electron-builder --publish always --x64 --linux "-c.publish.owner=${{ github.repository_owner }}" "-c.publish.repo=${{ github.event.repository.name }}"


### PR DESCRIPTION
This simple PR allows the execution of `publish.yml` in forked repos.

The `-c.publish.repo` should be transparent on the original repo.

The new write permission is because of: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/