### PR TITLE
feat: let the user choose where built firmware is saved

### DIFF
--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -251,6 +251,9 @@
     "ApplyUpdates": "A new version has been downloaded. Restart the application to apply the updates."
   },
   "ConfiguratorView": {
+    "FirmwareOutputFolderDialogTitle": "Select firmware output folder",
+    "FirmwareOutputFolderDialogMessage": "A folder for this build is created in the selected location",
+    "FirmwareOutputFolderError": "Failed to save the firmware files into the selected folder.",
     "DownloadLUAScript": "Download LUA script",
     "FirmwareVersion": "Firmware version",
     "Target": "Target",
@@ -302,7 +305,17 @@
     "ThemeSelector": "Theme",
     "ThemeSystem": "System (follow OS preference)",
     "ThemeLight": "Light",
-    "ThemeDark": "Dark"
+    "ThemeDark": "Dark",
+    "FirmwareOutput": "Firmware Output Folder",
+    "FirmwareOutputTemporaryFolder": "Temporary folder",
+    "FirmwareOutputAskEveryTime": "Ask me where to save after every build (default)",
+    "FirmwareOutputFixedFolder": "Always save into the same folder",
+    "FirmwareOutputFolder": "Output folder",
+    "FirmwareOutputFolderNotSet": "No folder selected yet",
+    "FirmwareOutputChooseFolder": "Choose folder",
+    "FirmwareOutputDescription": "Choose where firmware binaries are kept after a build. A folder named after the firmware is created in the selected location. Temporary folders are cleaned up by the operating system, so pick one of the other options if you want to keep your builds.",
+    "FirmwareOutputFolderDialogTitle": "Select firmware output folder",
+    "FirmwareOutputFolderDialogMessage": "A folder for every build is created in the selected location"
   },
   "SupportView": {
     "Support": "Support",

--- a/src/ipc/index.ts
+++ b/src/ipc/index.ts
@@ -4,6 +4,7 @@ export enum IpcRequest {
   UpdateBuildStatus = 'UPDATE_BUILD_STATUS',
   ChooseFolder = 'CHOOSE_FOLDER',
   SaveFile = 'SAVE_FILE',
+  SaveBuildOutput = 'SAVE_BUILD_OUTPUT',
   DownloadFile = 'DOWNLOAD_FILE',
 }
 
@@ -13,6 +14,12 @@ export interface OpenFileLocationRequestBody {
 
 export interface UpdateBuildStatusRequestBody {
   buildInProgress: boolean;
+}
+
+export interface ChooseFolderRequestBody {
+  title?: string;
+  message?: string;
+  defaultPath?: string;
 }
 
 export interface ChooseFolderResponseBody {
@@ -28,6 +35,32 @@ export interface SaveFileRequestBody {
 export interface SaveFileResponseBody {
   success: boolean;
   path: string;
+}
+
+export interface SaveBuildOutputRequestBody {
+  /**
+   * Firmware binary produced by the build. Every file that sits next to it is
+   * considered a build artefact and is copied along with it.
+   */
+  firmwareBinPath: string;
+  /**
+   * When set, artefacts are copied into this directory without asking the
+   * user. When empty, a folder selection dialog is shown.
+   */
+  destinationDirectory?: string;
+  title?: string;
+  message?: string;
+}
+
+export interface SaveBuildOutputResponseBody {
+  success: boolean;
+  /** true when the user dismissed the folder selection dialog */
+  canceled: boolean;
+  /** folder the artefacts have been copied into */
+  directoryPath: string;
+  /** firmware binary inside directoryPath */
+  firmwareBinPath: string;
+  message?: string;
 }
 
 export interface DownloadFileRequestBody {

--- a/src/ipc/index.ts
+++ b/src/ipc/index.ts
@@ -48,6 +48,11 @@ export interface SaveBuildOutputRequestBody {
    * user. When empty, a folder selection dialog is shown.
    */
   destinationDirectory?: string;
+  /**
+   * Name of the folder that is created for this build. Falls back to the
+   * firmware filename when empty.
+   */
+  folderName?: string;
   title?: string;
   message?: string;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,6 +11,7 @@ import 'reflect-metadata';
 import path from 'path';
 import { app, BrowserWindow, dialog, ipcMain, shell, session } from 'electron';
 import { mkdirp } from 'mkdirp';
+import sanitize from 'sanitize-filename';
 import winston from 'winston';
 import fs from 'fs';
 import { URL } from 'url';
@@ -580,10 +581,20 @@ ipcMain.handle(
 );
 
 /**
- * Name of the folder that is created for a single build, derived from the
- * canonical firmware filename, ie. "MyTX-3.5.6.bin.gz" -> "MyTX-3.5.6".
+ * Name of the folder that is created for a single build. The device target is
+ * used when the renderer knows it, because build artefacts are not always
+ * named after the target, ie. a WiFi build produces a plain "firmware.bin.gz".
+ * Otherwise the firmware filename is used, ie. "MyTX-3.5.6.bin.gz" ->
+ * "MyTX-3.5.6".
  */
-const buildOutputFolderName = (firmwareBinPath: string): string => {
+const buildOutputFolderName = (
+  firmwareBinPath: string,
+  requestedName?: string,
+): string => {
+  const sanitized = sanitize(requestedName ?? '', { replacement: '_' }).trim();
+  if (sanitized.length > 0) {
+    return sanitized;
+  }
   return path
     .basename(firmwareBinPath)
     .replace(/\.gz$/i, '')
@@ -630,7 +641,7 @@ ipcMain.handle(
 
       const outputDirectory = path.join(
         parentDirectory,
-        buildOutputFolderName(arg.firmwareBinPath),
+        buildOutputFolderName(arg.firmwareBinPath, arg.folderName),
       );
       await mkdirp(outputDirectory);
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -17,10 +17,13 @@ import { URL } from 'url';
 import MenuBuilder from './menu';
 import ApiServer from '../api';
 import {
+  ChooseFolderRequestBody,
   ChooseFolderResponseBody,
   DownloadFileRequestBody,
   IpcRequest,
   OpenFileLocationRequestBody,
+  SaveBuildOutputRequestBody,
+  SaveBuildOutputResponseBody,
   SaveFileRequestBody,
   SaveFileResponseBody,
   UpdateBuildStatusRequestBody,
@@ -511,11 +514,16 @@ ipcMain.on(
 
 ipcMain.handle(
   IpcRequest.ChooseFolder,
-  async (): Promise<ChooseFolderResponseBody> => {
+  async (
+    _,
+    args?: [ChooseFolderRequestBody?],
+  ): Promise<ChooseFolderResponseBody> => {
+    const arg = args?.[0];
     const result = await dialog.showOpenDialog({
-      title: 'Select firmware source folder',
-      message: 'Folder must contain platformio.ini file',
-      properties: ['openDirectory'],
+      title: arg?.title ?? 'Select firmware source folder',
+      message: arg?.message ?? 'Folder must contain platformio.ini file',
+      defaultPath: arg?.defaultPath,
+      properties: ['openDirectory', 'createDirectory'],
     });
     if (result.canceled || result.filePaths.length === 0) {
       return {
@@ -568,6 +576,94 @@ ipcMain.handle(
       success: true,
       path: result.filePath,
     };
+  },
+);
+
+/**
+ * Name of the folder that is created for a single build, derived from the
+ * canonical firmware filename, ie. "MyTX-3.5.6.bin.gz" -> "MyTX-3.5.6".
+ */
+const buildOutputFolderName = (firmwareBinPath: string): string => {
+  return path
+    .basename(firmwareBinPath)
+    .replace(/\.gz$/i, '')
+    .replace(/\.(elrs|bin|hex)$/i, '');
+};
+
+ipcMain.handle(
+  IpcRequest.SaveBuildOutput,
+  async (
+    _,
+    args: [SaveBuildOutputRequestBody],
+  ): Promise<SaveBuildOutputResponseBody> => {
+    const arg = args[0];
+    const failure = (message: string, canceled = false) => ({
+      success: false,
+      canceled,
+      directoryPath: '',
+      firmwareBinPath: '',
+      message,
+    });
+    logger.log('received a request to save build output', {
+      firmwareBinPath: arg.firmwareBinPath,
+      destinationDirectory: arg.destinationDirectory,
+    });
+    try {
+      if (!fs.existsSync(arg.firmwareBinPath)) {
+        return failure(`Firmware binary not found: ${arg.firmwareBinPath}`);
+      }
+
+      let parentDirectory = arg.destinationDirectory ?? '';
+      if (parentDirectory.length === 0) {
+        const result = await dialog.showOpenDialog({
+          title: arg.title ?? 'Select firmware output folder',
+          message:
+            arg.message
+            ?? 'A folder for this build is created in the selected location',
+          properties: ['openDirectory', 'createDirectory'],
+        });
+        if (result.canceled || result.filePaths.length === 0) {
+          return failure('', true);
+        }
+        parentDirectory = result.filePaths[0];
+      }
+
+      const outputDirectory = path.join(
+        parentDirectory,
+        buildOutputFolderName(arg.firmwareBinPath),
+      );
+      await mkdirp(outputDirectory);
+
+      const sourceDirectory = path.dirname(arg.firmwareBinPath);
+      const artefacts = (
+        await fs.promises.readdir(sourceDirectory, { withFileTypes: true })
+      ).filter((item) => item.isFile());
+      await Promise.all(
+        artefacts.map((item) =>
+          fs.promises.copyFile(
+            path.join(sourceDirectory, item.name),
+            path.join(outputDirectory, item.name),
+          ),
+        ),
+      );
+
+      logger.log('build output saved', {
+        outputDirectory,
+        artefacts: artefacts.map((item) => item.name),
+      });
+      return {
+        success: true,
+        canceled: false,
+        directoryPath: outputDirectory,
+        firmwareBinPath: path.join(
+          outputDirectory,
+          path.basename(arg.firmwareBinPath),
+        ),
+      };
+    } catch (err) {
+      logger.error('failed to save build output', (err as Error)?.stack);
+      return failure(`Failed to save firmware files: ${err}`);
+    }
   },
 );
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -8,6 +8,7 @@ export type Channels =
   | IpcRequest.DownloadFile
   | IpcRequest.OpenFileLocation
   | IpcRequest.OpenLogsFolder
+  | IpcRequest.SaveBuildOutput
   | IpcRequest.SaveFile
   | IpcRequest.UpdateBuildStatus;
 

--- a/src/ui/context/AppStateProvider.tsx
+++ b/src/ui/context/AppStateProvider.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useMemo, useState } from 'react';
 import AppState from '../models/AppState';
 import AppStatus from '../models/enum/AppStatus';
+import FirmwareOutputMode from '../models/enum/FirmwareOutputMode';
 import ThemeMode from '../models/enum/ThemeMode';
 import ApplicationStorage from '../storage';
 
@@ -12,6 +13,8 @@ export const AppStateContext = React.createContext<{
         appStatus: AppStatus.Interactive,
         isExpertModeEnabled: false,
         themeMode: ThemeMode.System,
+        firmwareOutputMode: FirmwareOutputMode.AskEveryTime,
+        firmwareOutputFolder: '',
       },
       setAppState: () => {},
     });
@@ -33,6 +36,19 @@ const parseThemeMode = (value: string | null): ThemeMode => {
   }
 };
 
+const parseFirmwareOutputMode = (value: string | null): FirmwareOutputMode => {
+  switch (value) {
+    case FirmwareOutputMode.AskEveryTime:
+      return FirmwareOutputMode.AskEveryTime;
+    case FirmwareOutputMode.FixedFolder:
+      return FirmwareOutputMode.FixedFolder;
+    case FirmwareOutputMode.TemporaryFolder:
+      return FirmwareOutputMode.TemporaryFolder;
+    default:
+      return FirmwareOutputMode.AskEveryTime;
+  }
+};
+
 const AppStateProvider: FunctionComponent<AppStateProviderContextProps> = ({
   children,
 }) => {
@@ -42,12 +58,18 @@ const AppStateProvider: FunctionComponent<AppStateProviderContextProps> = ({
       appStatus: AppStatus.Interactive,
       isExpertModeEnabled: storage.getExpertModeEnabled() ?? false,
       themeMode: parseThemeMode(storage.getThemeMode()),
+      firmwareOutputMode: parseFirmwareOutputMode(
+        storage.getFirmwareOutputMode(),
+      ),
+      firmwareOutputFolder: storage.getFirmwareOutputFolder() ?? '',
     };
   });
   const preSetAppState = (state: AppState) => {
     const storage = new ApplicationStorage();
     storage.setExpertModeEnabled(state.isExpertModeEnabled);
     storage.setThemeMode(state.themeMode);
+    storage.setFirmwareOutputMode(state.firmwareOutputMode);
+    storage.setFirmwareOutputFolder(state.firmwareOutputFolder);
     setAppState(state);
   };
   const value = useMemo(

--- a/src/ui/models/AppState.tsx
+++ b/src/ui/models/AppState.tsx
@@ -1,8 +1,11 @@
 import AppStatus from './enum/AppStatus';
+import FirmwareOutputMode from './enum/FirmwareOutputMode';
 import ThemeMode from './enum/ThemeMode';
 
 export default interface AppState {
   appStatus: AppStatus;
   isExpertModeEnabled: boolean;
   themeMode: ThemeMode;
+  firmwareOutputMode: FirmwareOutputMode;
+  firmwareOutputFolder: string;
 }

--- a/src/ui/models/enum/FirmwareOutputMode.tsx
+++ b/src/ui/models/enum/FirmwareOutputMode.tsx
@@ -1,0 +1,10 @@
+enum FirmwareOutputMode {
+  /** firmware stays in the temporary folder it was built in */
+  TemporaryFolder = 'temporary_folder',
+  /** ask for a destination folder after every build (default) */
+  AskEveryTime = 'ask_every_time',
+  /** always copy the firmware into a folder configured by the user */
+  FixedFolder = 'fixed_folder',
+}
+
+export default FirmwareOutputMode;

--- a/src/ui/storage/index.ts
+++ b/src/ui/storage/index.ts
@@ -60,6 +60,14 @@ export interface IApplicationStorage {
 
   getThemeMode(): string | null;
 
+  setFirmwareOutputMode(value: string): void;
+
+  getFirmwareOutputMode(): string | null;
+
+  setFirmwareOutputFolder(value: string): void;
+
+  getFirmwareOutputFolder(): string | null;
+
   getBindingPhraseHistory(): Promise<string[]>;
 
   addBindingPhraseToHistory(phrase: string): Promise<void>;
@@ -72,6 +80,8 @@ const FIRMWARE_SOURCE_KEY = 'firmware_source';
 const UI_SHOW_FIRMWARE_PRE_RELEASES = 'ui_show_pre_releases';
 const EXPERT_MODE = 'expert_mode';
 const THEME_MODE_KEY = 'theme_mode';
+const FIRMWARE_OUTPUT_MODE_KEY = 'firmware_output_mode';
+const FIRMWARE_OUTPUT_FOLDER_KEY = 'firmware_output_folder';
 const BINDING_PHRASE_HISTORY_KEY = 'binding_phrase_history';
 const BINDING_PHRASE_HISTORY_LIMIT = 15;
 
@@ -274,6 +284,22 @@ export default class ApplicationStorage implements IApplicationStorage {
 
   getThemeMode(): string | null {
     return localStorage.getItem(THEME_MODE_KEY);
+  }
+
+  setFirmwareOutputMode(value: string): void {
+    localStorage.setItem(FIRMWARE_OUTPUT_MODE_KEY, value);
+  }
+
+  getFirmwareOutputMode(): string | null {
+    return localStorage.getItem(FIRMWARE_OUTPUT_MODE_KEY);
+  }
+
+  setFirmwareOutputFolder(value: string): void {
+    localStorage.setItem(FIRMWARE_OUTPUT_FOLDER_KEY, value);
+  }
+
+  getFirmwareOutputFolder(): string | null {
+    return localStorage.getItem(FIRMWARE_OUTPUT_FOLDER_KEY);
   }
 
   async getBindingPhraseHistory(): Promise<string[]> {

--- a/src/ui/views/ConfiguratorView/buildOutputFolderName.test.ts
+++ b/src/ui/views/ConfiguratorView/buildOutputFolderName.test.ts
@@ -1,0 +1,65 @@
+import {
+  FirmwareSource,
+  FlashingMethod,
+  Target,
+} from '../../gql/generated/types';
+import buildOutputFolderName from './buildOutputFolderName';
+
+const target: Target = {
+  __typename: 'Target',
+  id: 'Happymodel_EP_2400_RX_via_WIFI',
+  name: 'Happymodel_EP_2400_RX_via_WIFI',
+  flashingMethod: FlashingMethod.WIFI,
+};
+
+describe('buildOutputFolderName', () => {
+  it('adds the firmware tag to the device target', () => {
+    expect(
+      buildOutputFolderName(target, {
+        source: FirmwareSource.GitTag,
+        gitTag: '3.5.6',
+      }),
+    ).toEqual('Happymodel_EP_2400_RX_via_WIFI-3.5.6');
+  });
+
+  it('adds the branch name to the device target', () => {
+    expect(
+      buildOutputFolderName(target, {
+        source: FirmwareSource.GitBranch,
+        gitBranch: 'master',
+      }),
+    ).toEqual('Happymodel_EP_2400_RX_via_WIFI-master');
+  });
+
+  it('adds the pull request number to the device target', () => {
+    expect(
+      buildOutputFolderName(target, {
+        source: FirmwareSource.GitPullRequest,
+        gitPullRequest: {
+          id: 1,
+          number: 2810,
+          title: 'a pull request',
+          headCommitHash: '8a4b0c1',
+        },
+      }),
+    ).toEqual('Happymodel_EP_2400_RX_via_WIFI-PR_2810');
+  });
+
+  it('falls back to the device target alone', () => {
+    expect(
+      buildOutputFolderName(target, {
+        source: FirmwareSource.Local,
+        localPath: '/home/user/ExpressLRS',
+      }),
+    ).toEqual('Happymodel_EP_2400_RX_via_WIFI');
+  });
+
+  it('returns nothing without a device target', () => {
+    expect(
+      buildOutputFolderName(null, {
+        source: FirmwareSource.GitTag,
+        gitTag: '3.5.6',
+      }),
+    ).toEqual('');
+  });
+});

--- a/src/ui/views/ConfiguratorView/buildOutputFolderName.ts
+++ b/src/ui/views/ConfiguratorView/buildOutputFolderName.ts
@@ -1,0 +1,32 @@
+import {
+  FirmwareSource,
+  FirmwareVersionDataInput,
+  Target,
+} from '../../gql/generated/types';
+
+/**
+ * Folder the firmware of a build is saved into, ie.
+ * "Happymodel_EP_2400_RX_via_WIFI-3.5.6". Build artefacts are not always named
+ * after the device target, so the folder keeps that information visible.
+ */
+export default function buildOutputFolderName(
+  target: Target | null,
+  firmwareVersion: FirmwareVersionDataInput | null,
+): string {
+  const targetName = target?.name ?? '';
+  if (targetName.length === 0) {
+    return '';
+  }
+  switch (firmwareVersion?.source) {
+    case FirmwareSource.GitTag:
+      return `${targetName}-${firmwareVersion.gitTag}`;
+    case FirmwareSource.GitBranch:
+      return `${targetName}-${firmwareVersion.gitBranch}`;
+    case FirmwareSource.GitCommit:
+      return `${targetName}-${firmwareVersion.gitCommit}`;
+    case FirmwareSource.GitPullRequest:
+      return `${targetName}-PR_${firmwareVersion.gitPullRequest?.number}`;
+    default:
+      return targetName;
+  }
+}

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -74,6 +74,8 @@ import {
   DownloadFileRequestBody,
   IpcRequest,
   OpenFileLocationRequestBody,
+  SaveBuildOutputRequestBody,
+  SaveBuildOutputResponseBody,
   SaveFileRequestBody,
   SaveFileResponseBody,
   UpdateBuildStatusRequestBody,
@@ -90,6 +92,7 @@ import WifiDeviceList from '../../components/WifiDeviceList';
 import GitRepository from '../../models/GitRepository';
 import ShowTimeoutAlerts from '../../components/ShowTimeoutAlerts';
 import useAppState from '../../hooks/useAppState';
+import FirmwareOutputMode from '../../models/enum/FirmwareOutputMode';
 import AppStatus from '../../models/enum/AppStatus';
 import MainLayout from '../../layouts/MainLayout';
 
@@ -193,7 +196,11 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
     ViewState.Configuration,
   );
 
-  const { setAppStatus } = useAppState();
+  const { setAppStatus, firmwareOutputMode, firmwareOutputFolder }
+    = useAppState();
+  const [firmwareOutputError, setFirmwareOutputError] = useState<string | null>(
+    null,
+  );
 
   const [firmwareVersionData, setFirmwareVersionData]
     = useState<FirmwareVersionDataInput | null>(null);
@@ -425,17 +432,64 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
     },
   ] = useMutation(BuildFlashFirmwareDocument);
 
+  const showInFileExplorer = useCallback((firmwareBinPath: string) => {
+    const body: OpenFileLocationRequestBody = {
+      path: firmwareBinPath,
+    };
+    window.electron.ipcRenderer.sendMessage(IpcRequest.OpenFileLocation, body);
+  }, []);
+
   useEffect(() => {
-    const arg = response?.buildFlashFirmware?.firmwareBinPath;
-    if (arg !== undefined && arg !== null && arg?.length > 0) {
-      const body: OpenFileLocationRequestBody = {
-        path: arg,
-      };
-      window.electron.ipcRenderer.sendMessage(
-        IpcRequest.OpenFileLocation,
-        body,
-      );
+    const firmwareBinPath = response?.buildFlashFirmware?.firmwareBinPath;
+    if (
+      firmwareBinPath === undefined
+      || firmwareBinPath === null
+      || firmwareBinPath.length === 0
+    ) {
+      return;
     }
+
+    // the firmware is built into a temporary folder, from there it is copied to
+    // wherever the user wants to keep it
+    if (firmwareOutputMode === FirmwareOutputMode.TemporaryFolder) {
+      showInFileExplorer(firmwareBinPath);
+      return;
+    }
+
+    const saveBuildOutput = async () => {
+      const body: SaveBuildOutputRequestBody = {
+        firmwareBinPath,
+        destinationDirectory:
+          firmwareOutputMode === FirmwareOutputMode.FixedFolder
+            ? firmwareOutputFolder
+            : '',
+        title: t('ConfiguratorView.FirmwareOutputFolderDialogTitle'),
+        message: t('ConfiguratorView.FirmwareOutputFolderDialogMessage'),
+      };
+      const result: SaveBuildOutputResponseBody
+        = await window.electron.ipcRenderer.invoke(
+          IpcRequest.SaveBuildOutput,
+          body,
+        );
+      if (result.success) {
+        setFirmwareOutputError(null);
+        showInFileExplorer(result.firmwareBinPath);
+        return;
+      }
+      if (result.canceled) {
+        // the user decided not to keep the firmware, it stays in the temporary
+        // folder until the operating system cleans it up
+        return;
+      }
+      setFirmwareOutputError(
+        result.message ?? t('ConfiguratorView.FirmwareOutputFolderError'),
+      );
+    };
+
+    saveBuildOutput().catch((err) => {
+      console.error('failed to save firmware output: ', err);
+      setFirmwareOutputError(`${err}`);
+    });
   }, [response]);
 
   const eraseSupported = useMemo(() => {
@@ -1157,6 +1211,7 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
             />
 
             <ShowAlerts severity="error" messages={buildFlashErrorResponse} />
+            <ShowAlerts severity="error" messages={firmwareOutputError} />
           </CardContent>
 
           {hasErrorInSession && (

--- a/src/ui/views/ConfiguratorView/index.tsx
+++ b/src/ui/views/ConfiguratorView/index.tsx
@@ -93,6 +93,7 @@ import GitRepository from '../../models/GitRepository';
 import ShowTimeoutAlerts from '../../components/ShowTimeoutAlerts';
 import useAppState from '../../hooks/useAppState';
 import FirmwareOutputMode from '../../models/enum/FirmwareOutputMode';
+import buildOutputFolderName from './buildOutputFolderName';
 import AppStatus from '../../models/enum/AppStatus';
 import MainLayout from '../../layouts/MainLayout';
 
@@ -459,6 +460,7 @@ const ConfiguratorView: FunctionComponent<ConfiguratorViewProps> = (props) => {
     const saveBuildOutput = async () => {
       const body: SaveBuildOutputRequestBody = {
         firmwareBinPath,
+        folderName: buildOutputFolderName(deviceTarget, firmwareVersionData),
         destinationDirectory:
           firmwareOutputMode === FirmwareOutputMode.FixedFolder
             ? firmwareOutputFolder

--- a/src/ui/views/SettingsView/index.tsx
+++ b/src/ui/views/SettingsView/index.tsx
@@ -1,4 +1,6 @@
 import {
+  Box,
+  Button,
   Card,
   CardContent,
   Checkbox,
@@ -7,12 +9,14 @@ import {
   FormControlLabel,
   Radio,
   RadioGroup,
+  TextField,
 } from '@mui/material';
 import { ChangeEvent, FunctionComponent } from 'react';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LanguageIcon from '@mui/icons-material/Language';
 import DeveloperModeIcon from '@mui/icons-material/DeveloperMode';
 import Brightness6Icon from '@mui/icons-material/Brightness6';
+import FolderIcon from '@mui/icons-material/Folder';
 import { useTranslation } from 'react-i18next';
 import CardTitle from '../../components/CardTitle';
 import MainLayout from '../../layouts/MainLayout';
@@ -20,6 +24,8 @@ import Omnibox, { Option } from '../../components/Omnibox';
 import locales from '../../../i18n/locales.json';
 import useAppState from '../../hooks/useAppState';
 import ThemeMode from '../../models/enum/ThemeMode';
+import FirmwareOutputMode from '../../models/enum/FirmwareOutputMode';
+import { ChooseFolderResponseBody, IpcRequest } from '../../../ipc';
 
 const SettingsView: FunctionComponent = () => {
   const { t, i18n } = useTranslation();
@@ -67,6 +73,37 @@ const SettingsView: FunctionComponent = () => {
     });
   };
 
+  const onFirmwareOutputModeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setAppState({
+      ...appState,
+      firmwareOutputMode: event.target.value as FirmwareOutputMode,
+    });
+  };
+
+  const onChooseFirmwareOutputFolder = () => {
+    window.electron.ipcRenderer
+      .invoke(IpcRequest.ChooseFolder, {
+        title: t('SettingsView.FirmwareOutputFolderDialogTitle'),
+        message: t('SettingsView.FirmwareOutputFolderDialogMessage'),
+        defaultPath:
+          appState.firmwareOutputFolder.length > 0
+            ? appState.firmwareOutputFolder
+            : undefined,
+      })
+      .then((result: ChooseFolderResponseBody) => {
+        if (result.success) {
+          setAppState({
+            ...appState,
+            firmwareOutputFolder: result.directoryPath,
+          });
+        }
+        return null;
+      })
+      .catch((err) => {
+        console.error('failed to select firmware output folder: ', err);
+      });
+  };
+
   return (
     <MainLayout>
       <Card>
@@ -112,6 +149,61 @@ const SettingsView: FunctionComponent = () => {
               />
             </RadioGroup>
           </FormControl>
+        </CardContent>
+        <Divider />
+        <CardTitle
+          icon={<FolderIcon />}
+          title={t('SettingsView.FirmwareOutput')}
+        />
+        <CardContent style={{ paddingLeft: 26, marginTop: -18 }}>
+          <FormControl>
+            <RadioGroup
+              value={appState.firmwareOutputMode}
+              onChange={onFirmwareOutputModeChange}
+            >
+              <FormControlLabel
+                value={FirmwareOutputMode.TemporaryFolder}
+                control={<Radio />}
+                label={t('SettingsView.FirmwareOutputTemporaryFolder')}
+              />
+              <FormControlLabel
+                value={FirmwareOutputMode.AskEveryTime}
+                control={<Radio />}
+                label={t('SettingsView.FirmwareOutputAskEveryTime')}
+              />
+              <FormControlLabel
+                value={FirmwareOutputMode.FixedFolder}
+                control={<Radio />}
+                label={t('SettingsView.FirmwareOutputFixedFolder')}
+              />
+            </RadioGroup>
+          </FormControl>
+          {appState.firmwareOutputMode === FirmwareOutputMode.FixedFolder && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 2,
+                marginTop: 1,
+              }}
+            >
+              <TextField
+                size="small"
+                fullWidth
+                label={t('SettingsView.FirmwareOutputFolder')}
+                value={appState.firmwareOutputFolder}
+                slotProps={{ input: { readOnly: true } }}
+                placeholder={t('SettingsView.FirmwareOutputFolderNotSet')}
+              />
+              <Button
+                variant="contained"
+                onClick={onChooseFirmwareOutputFolder}
+              >
+                {t('SettingsView.FirmwareOutputChooseFolder')}
+              </Button>
+            </Box>
+          )}
+          <p>{t('SettingsView.FirmwareOutputDescription')}</p>
         </CardContent>
         <Divider />
         <CardTitle


### PR DESCRIPTION
## Problem

Firmware built with the **Build** job type (for example a WiFi build, where the
binary is uploaded through the device's web interface afterwards) is copied into
a temporary directory created with `os.tmpdir()` and that directory is opened in
the file explorer.

The operating system cleans temporary directories up, so the binary has to be
moved somewhere safe manually, out of a path like
`C:\Users\<user>\AppData\Local\Temp\TX_ESP32_a7f3k2\`, before it disappears.
There is currently no way to tell the configurator where builds should end up.

## Change

The destination of a build is now configurable in **Settings → Firmware Output
Folder**:

- **Ask me where to save after every build** (default) – a folder selection
  dialog is shown after every successful build
- **Always save into the same folder** – builds are copied into a folder chosen
  once, without further interaction
- **Temporary folder** – previous behaviour

In the first two modes a folder named after the firmware is created inside the
selected location (`D:\ELRS\MyTX-3.5.6\`), so builds do not overwrite each
other, and every artefact of the build is copied into it. The file explorer is
opened at the new location, exactly as it was before.

Cancelling the dialog leaves the firmware in the temporary folder, so nothing is
lost if the dialog is dismissed by accident.

## Notes

- Only the `Build` job type is affected; flashing is untouched, since
  `firmwareBinPath` is only returned for builds.
- The copying itself happens in the main process (new `SAVE_BUILD_OUTPUT` IPC
  handler), the renderer only passes the localized dialog strings.
- `CHOOSE_FOLDER` accepts an optional title/message/default path now, so the
  settings screen can reuse it. Existing callers are unaffected.
- The setting is persisted in local storage next to the other application
  options.
- Only `en` translations are added, the remaining locales are managed by
  Crowdin.

If preferring no behaviour change out of the box, the default mode can be
switched to `FirmwareOutputMode.TemporaryFolder` in `AppStateProvider` — happy
to change that if you would rather have this opt-in.

## Testing

- `yarn typecheck` and `yarn lint`: no new errors
- Ran the configurator from source on Windows 11
