### PR TITLE
Clarify the "Passthrough" flashing method description

### DIFF
--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -112,7 +112,7 @@
     "UART": "This method allows you to flash your receiver or transmitter via its USB port or wiring up an FTDI device.",
     "WIFI": "This method creates a firmware file you can upload to your receiver or transmitter by connecting to its built in wifi.",
     "EdgeTxPassthrough": "This method allows you to flash your transmitter module while it is connected to your transmitter by using the passthrough feature of the EdgeTX firmware.",
-    "Passthrough": "This method allows you to flash your module while it is connected to your transmitter by using the passthrough feature.",
+    "Passthrough": "This method flashes the backpack through the USB port on the TX module, by putting the module's MCU into passthrough mode. The radio is not involved.",
     "Zip": "This method creates an archive of all files required for your device."
   },
   "FlashingMethodOptions": {


### PR DESCRIPTION
Fixes #698.

The old text said the module is flashed "while it is connected to your transmitter", which reads as if the radio takes part. It doesn't — this flashes the backpack through the USB port on the TX module, and that mismatch is what made the description confusing when the module is plugged straight into the PC.

Wording follows @pkendall64's explanation in the issue thread. English locale only; the rest comes via Crowdin.
