### PR TITLE
Rename "Betaflight Passthrough" flashing method to "FC Passthrough"

### DIFF
--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -101,7 +101,7 @@
   },
   "FlashingMethodDescription": {
     "BetaflightPassthroughDescription": "This method allows you to flash your receiver while it is connected to your flight controller by using the passthrough feature of the flight controller.",
-    "PlugInFCToComputer": "Plug in your FC to your computer, but do NOT connect to betaflight configurator.",
+    "PlugInFCToComputer": "Plug in your FC to your computer, but do NOT connect to your configurator software.",
     "SelectDesiredDevice": "Select your desired Device Options and your flight controllers serial device below.",
     "RunBuild&Flash": "Run Build & Flash.",
     "BetaflightPassthroughWiki": "Check our Wiki page for latest definition.",
@@ -149,7 +149,7 @@
     "SwitchToDarkTheme": "Switch to dark theme"
   },
   "FlashingMethod": {
-    "BetaflightPassthrough": "Betaflight Passthrough",
+    "BetaflightPassthrough": "FC Passthrough",
     "DFU": "DFU (Device Firmware Upgrade)",
     "EdgeTxPassthrough": "EdgeTX Passthrough",
     "Passthrough": "Passthrough",


### PR DESCRIPTION
Fixes #642.

The method is not Betaflight-specific: it relays serial data through the flight controller, which works the same on other Cleanflight derivatives, so naming one firmware in the label suggests the option does not apply to anyone else.

Also generalises the first step shown right below the label, which still told the user not to connect "betaflight configurator". The enum value and the method description are untouched — the description already said "the flight controller" rather than naming a firmware.

English locale only; the rest comes via Crowdin.
